### PR TITLE
Add Streaming RDF Form

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,11 @@
         specStatus: "ED",
         shortName: "json-ld-streaming",
         editors: [{
-          name: "Some Body"
+            name:       "Ruben Taelman",
+            url:        "https://www.rubensworks.net/",
+            company:    "Ghent University – imec",
+            companyURL: "http://idlab.ugent.be/",
+            w3cid:      "84199",
         }],
         wg:           "JSON-LD Working Group",
         wgURI:        "https://www.w3.org/2018/json-ld-wg/",

--- a/index.html
+++ b/index.html
@@ -376,7 +376,7 @@
     <section id="streaming-rdf-form">
       <h2>Streaming RDF Form</h2>
       <p>
-          This section introduces a <em>streaming RDF dataset form</em>,
+          This section introduces a <dfn data-dfn-type="dfn" id="dfn-streaming-RDF-dataset-form">streaming RDF dataset form</dfn>,
           which enables RDF datasets to be processed in a streaming manner
           so that they can efficiently serialized into JSON-LD by a streaming JSON-LD processor.
       </p>
@@ -425,7 +425,7 @@
               "http://schema.org/url": { "@id": "https://www.rubensworks.net/" }
             },
             {
-              "@id": "https://www.rubensworks.net/#me",
+              "@id": "https://greggkellogg.net/foaf#me",
               "http://schema.org/name": "Gregg Kellog",
               "http://schema.org/url": { "@id": "https://greggkellogg.net/" }
             }
@@ -442,11 +442,11 @@
               "http://schema.org/name": "Gregg Kellog"
             },
             {
-              "@id": "https://www.rubensworks.net/#me",
+              "@id": "https://greggkellogg.net/foaf#me",
               "http://schema.org/url": { "@id": "https://www.rubensworks.net/" }
             },
             {
-              "@id": "https://www.rubensworks.net/#me",
+              "@id": "https://greggkellogg.net/foaf#me",
               "http://schema.org/url": { "@id": "https://greggkellogg.net/" }
             }
           ]
@@ -493,6 +493,175 @@
             Existing triple stored may already perform this kind of grouping automatically.
             </p>
         </div>
+      </section>
+      <section>
+          <h3 id="streaming-rdf-examples">Examples</h3>
+          <p>
+              Hereafter, a couple of RDF datasets are listed, together with corresponding streamingly serialized JSON-LD.
+              Each example illustrates the importance of the recommended triple ordering within
+              the <a href="#dfn-streaming-RDF-dataset-form" class="internalDFN" data-link-type="dfn">streaming RDF dataset form</a>.
+          </p>
+          <p>
+              The examples using named graphs are serialized in the <a href="https://www.w3.org/TR/trig/">TriG</a> format.
+          </p>
+          <section>
+              <h3 id="streaming-rdf-example-graph">@graph grouping</h3>
+              <pre class="example" title="Triples with the same named graph are grouped">
+                @prefix schema: &lt;http://schema.org/&gt; .
+                &lt;http://example.org/graph1&gt; {
+                  &lt;https://www.rubensworks.net/#me&gt; schema:name "Ruben Taelman" .
+                }
+                &lt;http://example.org/graph1&gt; {
+                  &lt;https://www.rubensworks.net/#me&gt; schema:url &lt;https://www.rubensworks.net/&gt; .
+                }
+                &lt;http://example.org/graph2&gt; {
+                  &lt;https://greggkellogg.net/foaf#me&gt; schema:name "Gregg Kellog" .
+                }
+                &lt;http://example.org/graph2&gt; {
+                  &lt;https://greggkellogg.net/foaf#me&gt; schema:url &lt;https://greggkellogg.net/&gt; .
+                }
+              </pre>
+              <pre class="example" title="Triples with the same named graph can be grouped within the same @graph block">
+                [
+                  {
+                    "@id": "http://example.org/graph1",
+                    "@graph": [
+                      {
+                        "@id": "https://www.rubensworks.net/#me",
+                        "http://schema.org/name": "Ruben Taelman",
+                        "http://schema.org/url": { "@id": "https://www.rubensworks.net/" }
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "http://example.org/graph2",
+                    "@graph": [
+                      {
+                        "@id": "https://greggkellogg.net/foaf#me",
+                        "http://schema.org/name": "Gregg Kellog",
+                        "http://schema.org/url": { "@id": "https://greggkellogg.net/" }
+                      }
+                    ]
+                  }
+                ]
+              </pre>
+          </section>
+          <section>
+              <h3 id="streaming-rdf-example-id">@id grouping</h3>
+              <pre class="example" title="Triples with the same subject are grouped">
+                @prefix schema: &lt;http://schema.org/&gt; .
+                &lt;https://www.rubensworks.net/#me&gt; schema:name "Ruben Taelman" .
+                &lt;https://www.rubensworks.net/#me&gt; schema:url &lt;https://www.rubensworks.net/&gt; .
+                &lt;https://greggkellogg.net/foaf#me&gt; schema:name "Gregg Kellog" .
+                &lt;https://greggkellogg.net/foaf#me&gt; schema:url &lt;https://greggkellogg.net/&gt; .
+              </pre>
+              <pre class="example" title="Triples with the same subject can be grouped within the same @id block">
+                [
+                  {
+                    "@id": "https://www.rubensworks.net/#me",
+                    "http://schema.org/name": "Ruben Taelman",
+                    "http://schema.org/url": { "@id": "https://www.rubensworks.net/" }
+                  },
+                  {
+                    "@id": "https://greggkellogg.net/foaf#me",
+                    "http://schema.org/name": "Gregg Kellog",
+                    "http://schema.org/url": { "@id": "https://greggkellogg.net/" }
+                  }
+                ]
+              </pre>
+          </section>
+          <section>
+              <h3 id="streaming-rdf-example-property">Property grouping</h3>
+              <pre class="example" title="Triples with the same predicate are grouped">
+                @prefix schema: &lt;http://schema.org/&gt; .
+                &lt;https://www.rubensworks.net/#me&gt; schema:name "Ruben" .
+                &lt;https://www.rubensworks.net/#me&gt; schema:name "Ruben Taelman" .
+                &lt;https://www.rubensworks.net/#me&gt; schema:url &lt;https://www.rubensworks.net/&gt; .
+                &lt;https://www.rubensworks.net/#me&gt; schema:url &lt;https://github.com/rubensworks/&gt; .
+              </pre>
+              <pre class="example" title="Triples with the same predicate can be grouped within the same property array">
+                [
+                  {
+                    "@id": "https://www.rubensworks.net/#me",
+                    "http://schema.org/name": [
+                      "Ruben"
+                      "Ruben Taelman",
+                    ],
+                    "http://schema.org/url": [
+                      { "@id": "https://www.rubensworks.net/" },
+                      { "@id": "https://github.com/rubensworks/" }
+                    ]
+                  }
+                ]
+              </pre>
+          </section>
+          <section>
+              <h3 id="streaming-rdf-example-graph-id">@graph and @id grouping</h3>
+              <pre class="example" title="Statements about a named graph are group with triples within this named graph">
+                @prefix schema: &lt;http://schema.org/&gt; .
+                &lt;http://example.org/graph1&gt; {
+                  &lt;https://www.rubensworks.net/#me&gt; schema:name "Ruben Taelman" .
+                }
+                &lt;http://example.org/graph1&gt; {
+                  &lt;https://www.rubensworks.net/#me&gt; schema:url &lt;https://www.rubensworks.net/&gt; .
+                }
+                &lt;http://example.org/graph1&gt; schema:name "Graph 1" .
+                &lt;http://example.org/graph2&gt; {
+                  &lt;https://greggkellogg.net/foaf#me&gt; schema:name "Gregg Kellog" .
+                }
+                &lt;http://example.org/graph2&gt; {
+                  &lt;https://greggkellogg.net/foaf#me&gt; schema:url &lt;https://greggkellogg.net/&gt; .
+                }
+                &lt;http://example.org/graph2&gt; schema:name "Graph 2" .
+              </pre>
+              <pre class="example" title="Statements about a named graph can be attached within the same @graph block">
+                [
+                  {
+                    "@id": "http://example.org/graph1",
+                    "@graph": [
+                      {
+                        "@id": "https://www.rubensworks.net/#me",
+                        "http://schema.org/name": "Ruben Taelman",
+                        "http://schema.org/url": { "@id": "https://www.rubensworks.net/" }
+                      }
+                    ],
+                    "name": "Graph 1"
+                  },
+                  {
+                    "@id": "http://example.org/graph2",
+                    "@graph": [
+                      {
+                        "@id": "https://greggkellogg.net/foaf#me",
+                        "http://schema.org/name": "Gregg Kellog",
+                        "http://schema.org/url": { "@id": "https://greggkellogg.net/" }
+                      }
+                    ],
+                    "name": "Graph 2"
+                  }
+                ]
+              </pre>
+          </section>
+          <section>
+              <h3 id="streaming-rdf-example-object">Subject and object grouping</h3>
+              <pre class="example" title="Triples about a subject come right after triples having this as object">
+                @prefix schema: &lt;http://schema.org/&gt; .
+                &lt;https://www.rubensworks.net/#me&gt; schema:name "Ruben Taelman" .
+                &lt;https://www.rubensworks.net/#me&gt; schema:knows &lt;https://greggkellogg.net/foaf#me&gt; .
+                &lt;https://greggkellogg.net/foaf#me&gt; schema:knows "Gregg Kellog" .
+              </pre>
+              <pre class="example" title="Triples can be chained in nested nodes">
+                [
+                  {
+                    "@id": "https://www.rubensworks.net/#me",
+                    "http://schema.org/name": "Ruben Taelman",
+                    "http://schema.org/knows": {
+                      "@id": "https://greggkellogg.net/foaf#me",
+                      "http://schema.org/name": "Gregg Kellog"
+                    }
+                  }
+                ]
+              </pre>
+          </section>
       </section>
     </section>
     

--- a/index.html
+++ b/index.html
@@ -453,16 +453,46 @@
         </pre>
       </section>
       <section>
-        <h3 id="triple-ordering-required">Recommended Triple Ordering</h3>
+        <h3 id="triple-ordering-recommended">Recommended Triple Ordering</h3>
         <p>
-            TODO
+            This section introduces <em>recommendations</em> for defining the order in an RDF dataset,
+            such that it can be processed more efficiently by <em>streaming JSON-LD processors</em>.
         </p>
-      </section>
-      <section>
-        <h3 id="streaming-rdf-profile">Streaming RDF Profile</h3>
-        <p>
-            TODO
-        </p>
+        <ol>
+            <li>
+                <strong>Group triples with the same named graph.</strong>
+                <br />
+                Allows grouping of <code>@graph</code> nodes.
+            </li>
+            <li>
+                <strong>Group triples with the same subject.</strong>
+                <br />
+                Allows grouping of <code>@id</code> keys.
+            </li>
+            <li>
+                <strong>Group triples with the same predicate.</strong>
+                <br />
+                Allows grouping of property keys.
+            </li>
+            <li>
+                <strong>Group triples with a given term as named graph together with triples having this term as subject.</strong>
+                <br />
+                Allows the combination of <code>@graph</code> nodes with <code>@id</code>.
+            </li>
+            <li>
+                <strong>Group triples with a given term as object with triples having this term as object.</strong>
+                <br />
+                Allows nesting of nodes within other nodes.
+            </li>
+        </ol>
+        <div class="note" role="note" id="triple-ordering-recommended-how">
+            <p class="">
+            One straightforward way to follow most of these recommendations is by sorting all triples (or quads)
+            in the order <em>graph</em>, <em>subject</em>, <em>predicate</em>, <em>object</em>.
+            <br />
+            Existing triple stored may already perform this kind of grouping automatically.
+            </p>
+        </div>
       </section>
     </section>
     

--- a/index.html
+++ b/index.html
@@ -376,10 +376,84 @@
     <section id="streaming-rdf-form">
       <h2>Streaming RDF Form</h2>
       <p>
-          TODO: order in which RDF triples appear
+          This section introduces a <em>streaming RDF dataset form</em>,
+          which enables RDF datasets to be processed in a streaming manner
+          so that they can efficiently serialized into JSON-LD by a streaming JSON-LD processor.
       </p>
       <section>
-        <h3 id="triple-ordering-required">Required Triple Ordering</h3>
+        <h3 id="triple-ordering-importance">Importance of Triple Ordering</h3>
+        <p>
+            The order in which RDF triples occur in an RDF dataset convey no meaning.
+            For instance, the following two RDF datasets (serialized in <a href="https://www.w3.org/TR/turtle/">Turtle</a>) have the same meaning,
+            even though they have a different order of triples.
+        </p>
+        <pre class="example" title="A first order of triples">
+          @prefix schema: &lt;http://schema.org/&gt; .
+          &lt;https://www.rubensworks.net/#me&gt; schema:name "Ruben Taelman" .
+          &lt;https://www.rubensworks.net/#me&gt; schema:url &lt;https://www.rubensworks.net/&gt; .
+          &lt;https://greggkellogg.net/foaf#me&gt; schema:name "Gregg Kellog" .
+          &lt;https://greggkellogg.net/foaf#me&gt; schema:url &lt;https://greggkellogg.net/&gt; .
+        </pre>
+        <pre class="example" title="A second order of triples">
+          @prefix schema: &lt;http://schema.org/&gt; .
+          &lt;https://www.rubensworks.net/#me&gt; schema:name "Ruben Taelman" .
+          &lt;https://greggkellogg.net/foaf#me&gt; schema:name "Gregg Kellog" .
+          &lt;https://www.rubensworks.net/#me&gt; schema:url &lt;https://www.rubensworks.net/&gt; .
+          &lt;https://greggkellogg.net/foaf#me&gt; schema:url &lt;https://greggkellogg.net/&gt; .
+        </pre>
+        <p>
+            For streaming JSON-LD processors, the order of RDF triples can however become important.
+            Processors that read triples one by one, and convert them to a JSON-LD document in a streaming manner,
+            can benefit from having triples in a certain order.
+        </p>
+        <p>
+            For instance, the order from first snippet above can lead to more compact JSON-LD documents than the order from the second snippet
+            when handled by a streaming JSON-LD processor.
+            This is because the first order groups triples with the same subject,
+            which can be exploited during streaming JSON-LD serialization by using the same <code>"@id"</code> key.
+            The second order mixes subjects, which means that streaming JSON-LD serialization will have to assign separate <code>"@id"</code> keys
+            for each triple, resulting in duplicate <code>"@id"</code> keys.
+        </p>
+        <p>
+            Streaming JSON-LD serializations of both examples can be seen below.
+        </p>
+        <pre class="example" title="More compact JSON-LD serialization of the first order">
+          [
+            {
+              "@id": "https://www.rubensworks.net/#me",
+              "http://schema.org/name": "Ruben Taelman",
+              "http://schema.org/url": { "@id": "https://www.rubensworks.net/" }
+            },
+            {
+              "@id": "https://www.rubensworks.net/#me",
+              "http://schema.org/name": "Gregg Kellog",
+              "http://schema.org/url": { "@id": "https://greggkellogg.net/" }
+            }
+          ]
+        </pre>
+        <pre class="example" title="Less compact JSON-LD serialization of the second order">
+          [
+            {
+              "@id": "https://www.rubensworks.net/#me",
+              "http://schema.org/name": "Ruben Taelman"
+            },
+            {
+              "@id": "https://www.rubensworks.net/#me",
+              "http://schema.org/name": "Gregg Kellog"
+            },
+            {
+              "@id": "https://www.rubensworks.net/#me",
+              "http://schema.org/url": { "@id": "https://www.rubensworks.net/" }
+            },
+            {
+              "@id": "https://www.rubensworks.net/#me",
+              "http://schema.org/url": { "@id": "https://greggkellogg.net/" }
+            }
+          ]
+        </pre>
+      </section>
+      <section>
+        <h3 id="triple-ordering-required">Recommended Triple Ordering</h3>
         <p>
             TODO
         </p>

--- a/index.html
+++ b/index.html
@@ -683,7 +683,7 @@
             By reading character-by-character, a deserializer can detect the contained JSON nodes and its key-value pairs.
         </p>
         <p>
-            A streaming deserializer MAY assume that the <a href="#key-ordering-required">required key ordering of a <a href="#dfn-streaming-document-form" class="internalDFN" data-link-type="dfn">streaming document</a> is present. If a different order is detected, an error MAY be thrown with error code <code>"invalid streaming key order"</code>.
+            A streaming deserializer MAY assume that the <a href="#key-ordering-required">required key ordering</a> of a <a href="#dfn-streaming-document-form" class="internalDFN" data-link-type="dfn">streaming document</a> is present. If a different order is detected, an error MAY be thrown with error code <code>"invalid streaming key order"</code>.
         </p>
         <p>
             The first expected entry in a node is <code>@context</code>.
@@ -709,7 +709,39 @@
       <section>
         <h3 id="streaming-serialization">Serialization</h3>
         <p>
-            TODO
+            A streaming JSON-LD serializer reads triples one by one,
+            and outputs a JSON-LD document character-by-character,
+            which can be emitted in a streaming manner.
+            <br />
+            This MAY potentially be a JSON-LD document in the <a href="#dfn-streaming-document-form" class="internalDFN" data-link-type="dfn">streaming document form</a>.
+        </p>
+        <p>
+            A streaming serializer can benefit from having <a href="#triple-ordering-recommended">triples ordered</a> following a <a href="#dfn-streaming-RDF-dataset-form" class="internalDFN" data-link-type="dfn">streaming RDF dataset form</a>.
+        </p>
+        <p>
+            As a basis, a streaming serializer can produce an array of nodes,
+            where each node represent a single RDF triple/quad.
+        </p>
+        <p>
+            On top of this base case, several optimizations can be applied to achieve a more compact representation in JSON-LD.
+            These optimizations are dependent on the surrounding triples, which is determine by the overall triple order.
+        </p>
+        <p>
+            When a <a class="externalDFN" href="https://www.w3.org/TR/json-ld-syntaxt/#the-context">JSON-LD context</a>
+            is passed to a streaming serializer, <a class="externalDFN" href="https://www.w3.org/TR/json-ld-api/#compaction">compaction techniques</a>
+            MAY be applied.
+            For instance, instead of writing properties as full IRIs, they can be <em>compacted</em> based on the presence of terms and prefixes in the context.
+        </p>
+        <p>
+            Due to the chained nature of RDF lists, serializing them to JSON-LD with the <code>@list</code> keyword in a streaming way may not always be possible,
+            since you may not know beforehand whether a triple is part of a valid RDF list.
+            Optionally, a streaming RDF serializer MAY provide an alternative method to introduce <code>@list</code> keywords.
+        </p>
+        <p>
+            Since streaming RDF processors process triples one by one,
+            so that they don't need to keep all triples in memory,
+            they loose the ability to deduplicate triples.
+            As such, a streaming JSON-LD serializer MAY produce JSON-LD that contains duplicate triples.
         </p>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -184,6 +184,8 @@
             <p class="">
             This recommended key ordering SHOULD be followed by streaming document authors.
             Streaming processors implementations MUST NOT assume that a given streaming document will adhere to this recommendation.
+            <br />
+            If a processor sees that a document does not adhere to this recommendation, then it MAY produce a warning.
             </p>
         </div>
       </section>


### PR DESCRIPTION
This PR resolves all remaining TODOs, and fills in the sections on the streaming RDF dataset form.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: write EPROTO 139705468127104:error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version:../deps/openssl/openssl/ssl/s23_clnt.c:772:
 :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 12, 2020, 3:13 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fjson-ld-streaming%2Fpull%2F3%2F7d5a646.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Frubensworks%2Fjson-ld-streaming%2Fpull%2F3.html)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/json-ld-streaming%233.)._
</details>
