### PR TITLE
Add base files for implementation reports

### DIFF
--- a/reports/.earl
+++ b/reports/.earl
@@ -1,0 +1,22 @@
+---
+:format: :json
+:manifest: manifests.nt
+:bibRef: ! '[[json-ld11-streaming]]'
+:name: Streaming JSON-LD 1.1
+:query: |
+  PREFIX mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>
+  PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+  PREFIX jld: <https://w3c.github.io/json-ld-api/tests/vocab#>
+
+  SELECT ?uri ?testAction ?manUri
+  WHERE {
+    ?uri mf:action ?testAction .
+    OPTIONAL {
+      ?uri jld:option [jld:specVersion ?version] .
+    }
+    FILTER (!bound(?version) || ?version != 'json-ld-1.0')
+    OPTIONAL {
+      ?manUri a mf:Manifest; mf:entries ?lh .
+      ?lh rdf:first ?uri .
+    }
+  }

--- a/reports/README
+++ b/reports/README
@@ -1,0 +1,10 @@
+This is a collection of individual EARL reports for
+test subjects claiming Streaming JSON-LD Deserializer or Streaming JSON-LD Serializer conformance.
+
+The consolidated report is saved to index.html generated
+using the earl-report Ruby gem. Run it as follows:
+
+gem install earl-report
+
+earl-report --format json -o earl.jsonld *.ttl
+earl-report --json --format html --template template.haml -o index.html earl.jsonld

--- a/reports/Rakefile
+++ b/reports/Rakefile
@@ -1,0 +1,17 @@
+task default: [ "manifests.nt", "earl.ttl", "earl.html" ]
+
+desc "Create concatenated test manifests"
+file "manifests.nt" do
+  require 'rdf'
+  require 'json/ld'
+  require 'rdf/ntriples'
+  graph = RDF::Graph.new do |g|
+    %w( https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest.jsonld
+    ).each do |man|
+      puts "load #{man}"
+      g.load(man, unique_bnodes: true)
+    end
+  end
+  puts "write"
+  RDF::NTriples::Writer.open("manifests.nt", unique_bnodes: true, validate: false) {|w| w << graph}
+end

--- a/reports/earl.jsonld
+++ b/reports/earl.jsonld
@@ -1,0 +1,942 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@vocab": "http://www.w3.org/ns/earl#",
+    "foaf:homepage": {
+      "@type": "@id"
+    },
+    "dc": "http://purl.org/dc/terms/",
+    "doap": "http://usefulinc.com/ns/doap#",
+    "earl": "http://www.w3.org/ns/earl#",
+    "mf": "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#",
+    "foaf": "http://xmlns.com/foaf/0.1/",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "assertedBy": {
+      "@type": "@id"
+    },
+    "assertions": {
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "bibRef": {
+      "@id": "dc:bibliographicCitation"
+    },
+    "created": {
+      "@id": "doap:created",
+      "@type": "xsd:date"
+    },
+    "description": {
+      "@id": "rdfs:comment",
+      "@language": "en"
+    },
+    "developer": {
+      "@id": "doap:developer",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "doapDesc": {
+      "@id": "doap:description",
+      "@language": "en"
+    },
+    "generatedBy": {
+      "@type": "@id"
+    },
+    "homepage": {
+      "@id": "doap:homepage",
+      "@type": "@id"
+    },
+    "language": {
+      "@id": "doap:programming-language"
+    },
+    "license": {
+      "@id": "doap:license",
+      "@type": "@id"
+    },
+    "mode": {
+      "@type": "@id"
+    },
+    "name": {
+      "@id": "doap:name"
+    },
+    "outcome": {
+      "@type": "@id"
+    },
+    "release": {
+      "@id": "doap:release",
+      "@type": "@id"
+    },
+    "revision": {
+      "@id": "doap:revision"
+    },
+    "shortdesc": {
+      "@id": "doap:shortdesc",
+      "@language": "en"
+    },
+    "subject": {
+      "@type": "@id"
+    },
+    "test": {
+      "@type": "@id"
+    },
+    "testAction": {
+      "@id": "mf:action",
+      "@type": "@id"
+    },
+    "testResult": {
+      "@id": "mf:result",
+      "@type": "@id"
+    },
+    "title": {
+      "@id": "mf:name"
+    },
+    "entries": {
+      "@id": "mf:entries",
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "testSubjects": {
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "xsd": {
+      "@id": "http://www.w3.org/2001/XMLSchema#"
+    }
+  },
+  "@id": "",
+  "@type": [
+    "Software",
+    "doap:Project"
+  ],
+  "testSubjects": [
+    {
+      "@id": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+      "@type": [
+        "Software",
+        "TestSubject",
+        "doap:Project"
+      ],
+      "doapDesc": "Streaming JSON-LD parser",
+      "homepage": "https://github.com/rubensworks/jsonld-streaming-parser.js#readme",
+      "language": "JavaScript",
+      "developer": [
+        {
+          "@id": "https://www.rubensworks.net/#me",
+          "@type": [
+            "Assertor",
+            "foaf:Person"
+          ],
+          "foaf:name": "Ruben Taelman <rubensworks@gmail.com>",
+          "foaf:homepage": "https://www.rubensworks.net/"
+        }
+      ],
+      "name": "jsonld-streaming-parser",
+      "release": [
+        {
+          "revision": "unknown"
+        },
+        {
+          "revision": "unknown"
+        }
+      ]
+    }
+  ],
+  "bibRef": "[[json-ld11-streaming]]",
+  "generatedBy": {
+    "@id": "http://rubygems.org/gems/earl-report",
+    "@type": [
+      "Software",
+      "doap:Project"
+    ],
+    "doapDesc": "EarlReport generates HTML+RDFa rollups of multiple EARL reports",
+    "homepage": "https://github.com/gkellogg/earl-report",
+    "shortdesc": "Earl Report summary generator",
+    "developer": [
+      "http://greggkellogg.net/foaf#me"
+    ],
+    "name": "earl-report",
+    "license": "http://unlicense.org",
+    "release": {
+      "@id": "https://github.com/gkellogg/earl-report/tree/0.4.9",
+      "@type": "doap:Version",
+      "revision": "0.4.9",
+      "doap:created": {
+        "@value": "2020-03-15",
+        "@type": "http://www.w3.org/2001/XMLSchema#date"
+      },
+      "name": "earl-report-0.4.9"
+    },
+    "language": "Ruby"
+  },
+  "assertions": [
+    "jsonld-streaming-parser-earl.ttl"
+  ],
+  "entries": [
+    {
+      "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest",
+      "@type": [
+        "mf:Manifest",
+        "Report"
+      ],
+      "title": "Streaming",
+      "entries": [
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te001",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest"
+          ],
+          "title": "@context must come before @id",
+          "mf:result": "invalid streaming key order",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te001",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/e001-in.jsonld",
+          "rdfs:comment": "Generate an error if @context comes after @id"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te002",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest"
+          ],
+          "title": "@context must come before properties",
+          "mf:result": "invalid streaming key order",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te002",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/e002-in.jsonld",
+          "rdfs:comment": "Generate an error if @context comes after properties"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te003",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest"
+          ],
+          "title": "@context must come before @type with context",
+          "mf:result": "invalid streaming key order",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te003",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/e003-in.jsonld",
+          "rdfs:comment": "Generate an error if @context comes after @type with a type-scoped context"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te004",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest"
+          ],
+          "title": "@type with context must come before @id",
+          "mf:result": "invalid streaming key order",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te004",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/e004-in.jsonld",
+          "rdfs:comment": "Generate an error if @type with context comes after @id"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te005",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest"
+          ],
+          "title": "@type with context must come before properties",
+          "mf:result": "invalid streaming key order",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te005",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/e005-in.jsonld",
+          "rdfs:comment": "Generate an error if @type with context comes after properties"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te006",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest"
+          ],
+          "title": "Embedded @context must come before @id",
+          "mf:result": "invalid streaming key order",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te006",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/e006-in.jsonld",
+          "rdfs:comment": "Generate an error if embedded @context comes after @id"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te007",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest"
+          ],
+          "title": "Embedded @context must come before properties",
+          "mf:result": "invalid streaming key order",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te007",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/e007-in.jsonld",
+          "rdfs:comment": "Generate an error if embedded @context comes after properties"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv001",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
+          ],
+          "title": "@context, @id and properties",
+          "testResult": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv001-out.nq",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv001",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv001-in.jsonld",
+          "rdfs:comment": "@context, @id and properties"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv002",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
+          ],
+          "title": "@context, blank @id and properties",
+          "testResult": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv002-out.nq",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv002",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv002-in.jsonld",
+          "rdfs:comment": "@context, blank @id and properties"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv003",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
+          ],
+          "title": "@context, implicit @id and properties",
+          "testResult": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv003-out.nq",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv003",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv003-in.jsonld",
+          "rdfs:comment": "@context, implicit @id and properties"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv004",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
+          ],
+          "title": "Nested nodes",
+          "testResult": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv004-out.nq",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv004",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv004-in.jsonld",
+          "rdfs:comment": "Nested nodes"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv005",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
+          ],
+          "title": "Nested nodes and embedded context",
+          "testResult": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv005-out.nq",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv005",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv005-in.jsonld",
+          "rdfs:comment": "Nested nodes and embedded context"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv006",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
+          ],
+          "title": "@context, @type-scoped context, @id, and other properties",
+          "testResult": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv006-out.nq",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv006",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv006-in.jsonld",
+          "rdfs:comment": "@context, @type-scoped context, @id, and other properties"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv007",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
+          ],
+          "title": "@context, plain @type, @id, and other properties",
+          "testResult": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv007-out.nq",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv007",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv007-in.jsonld",
+          "rdfs:comment": "@type without an attached context may appear anywhere"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv008",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
+          ],
+          "title": "No @context and @id",
+          "testResult": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv008-out.nq",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv008",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv008-in.jsonld",
+          "rdfs:comment": "@context and @id are not required"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv009",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
+          ],
+          "title": "Deeply nested nodes",
+          "testResult": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv009-out.nq",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv009",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv009-in.jsonld",
+          "rdfs:comment": "Deeply nested nodes"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv010",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
+          ],
+          "title": "Deeply nested nodes without @id",
+          "testResult": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv010-out.nq",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv010",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv010-in.jsonld",
+          "rdfs:comment": "Deeply nested nodes without @id"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv011",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
+          ],
+          "title": "@id after properties",
+          "testResult": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv011-out.nq",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv011",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv011-in.jsonld",
+          "rdfs:comment": "Properties should be buffered until @id is encountered"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv012",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
+          ],
+          "title": "No @id after properties",
+          "testResult": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv012-out.nq",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv012",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv012-in.jsonld",
+          "rdfs:comment": "Properties should be buffered until node closes"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv013",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
+          ],
+          "title": "@id after properties in nested node",
+          "testResult": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv013-out.nq",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv013",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv013-in.jsonld",
+          "rdfs:comment": "Properties in nested node should be buffered until @id is encountered"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv014",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
+          ],
+          "title": "No @id after properties in nested node",
+          "testResult": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv014-out.nq",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv014",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv014-in.jsonld",
+          "rdfs:comment": "Properties in nested node should be buffered until node closes"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv015",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
+          ],
+          "title": "@id after properties in nested node with outer @id after node",
+          "testResult": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv015-out.nq",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv015",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv015-in.jsonld",
+          "rdfs:comment": "Properties in nested node with @id after node should be buffered until @id is encountered"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv016",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
+          ],
+          "title": "No @id after properties in nested node and no outer @id",
+          "testResult": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv016-out.nq",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv016",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv016-in.jsonld",
+          "rdfs:comment": "Properties in nested node and no outer @id should be buffered until node closes"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv017",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
+          ],
+          "title": "@id after @graph and properties",
+          "testResult": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv017-out.nq",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv017",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv017-in.jsonld",
+          "rdfs:comment": "Properties with @graph should be buffered until @id is encountered"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv018",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
+          ],
+          "title": "No @id after @graph and properties",
+          "testResult": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv018-out.nq",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv018",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv018-in.jsonld",
+          "rdfs:comment": "Properties with @graph should be buffered until node closes"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv019",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
+          ],
+          "title": "@id after @graph and properties and late inner @id",
+          "testResult": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv019-out.nq",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv019",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv019-in.jsonld",
+          "rdfs:comment": "Properties with @graph should be buffered until @id is encountered"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv020",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
+          ],
+          "title": "No @id after @graph and properties and late inner @id",
+          "testResult": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv020-out.nq",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv020",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv020-in.jsonld",
+          "rdfs:comment": "Properties with @graph should be buffered until node closes and @id is encountered"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv021",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
+          ],
+          "title": "@id after @graph and properties and no @id",
+          "testResult": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv021-out.nq",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv021",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv021-in.jsonld",
+          "rdfs:comment": "Properties with @graph should be buffered until node closes and @id is encountered"
+        },
+        {
+          "@id": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv022",
+          "@type": [
+            "TestCriterion",
+            "TestCase",
+            "https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest",
+            "https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest"
+          ],
+          "title": "No @id after @graph and properties and no @id",
+          "testResult": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv022-out.nq",
+          "assertions": [
+            {
+              "@type": "Assertion",
+              "subject": "https://www.npmjs.com/package/jsonld-streaming-parser/",
+              "assertedBy": "https://www.rubensworks.net/#me",
+              "test": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv022",
+              "mode": "earl:automatic",
+              "result": {
+                "@type": "TestResult",
+                "outcome": "earl:passed"
+              }
+            }
+          ],
+          "testAction": "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv022-in.jsonld",
+          "rdfs:comment": "Properties with @graph should be buffered until nodes close"
+        }
+      ],
+      "rdfs:comment": "JSON-LD Streaming tests.",
+      "https://w3c.github.io/json-ld-api/tests/vocab#baseIri": "https://w3c.github.io/json-ld-streaming/tests/"
+    }
+  ],
+  "name": "Streaming JSON-LD 1.1"
+}

--- a/reports/index.html
+++ b/reports/index.html
@@ -1,0 +1,591 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta content='text/html;charset=utf-8' http-equiv='Content-Type' />
+<link href='earl.jsonld' rel='alternate' />
+<link href='https://www.w3.org/StyleSheets/TR/base' rel='stylesheet' />
+<link href='jsonld-streaming-parser-earl.ttl' rel='related' />
+<title>
+Streaming JSON-LD 1.1 Processor Conformance
+</title>
+<style type='text/css'>
+  /*<![CDATA[*/
+    span[property='dc:description rdfs:comment'] { display: none; }
+    td.PASS { color: green; }
+    td.FAIL { color: red; }
+    table.report {
+      border-width: 1px;
+      border-spacing: 2px;
+      border-style: outset;
+      border-color: gray;
+      border-collapse: separate;
+      background-color: white;
+    }
+    table.report th {
+      border-width: 1px;
+      padding: 1px;
+      border-style: inset;
+      border-color: gray;
+      background-color: white;
+      -moz-border-radius: ;
+    }
+    table.report td {
+      border-width: 1px;
+      padding: 1px;
+      border-style: inset;
+      border-color: gray;
+      background-color: white;
+      -moz-border-radius: ;
+    }
+    tr.summary {font-weight: bold;}
+    td.passed-all {color: green;}
+    td.passed-most {color: darkorange;}
+    td.passed-some {color: red;}
+    em.rfc2119 {
+      text-transform: lowercase;
+      font-variant:   small-caps;
+      font-style:     normal;
+      color:          #900;
+    }
+    a.testlink {
+      color: inherit;
+      text-decoration: none;
+    }
+    a.testlink:hover {
+      text-decoration: underline;
+    }
+    pre > code {
+      color: #C83500;
+    }
+  /*]]>*/
+</style>
+</head>
+<body prefix='bibo: http://purl.org/ontology/bibo/ earl: http://www.w3.org/ns/earl# doap: http://usefulinc.com/ns/doap# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#' vocab='http://www.w3.org/ns/earl#'>
+<div class='head' role='contentinfo'>
+<p>
+<a href='http://www.w3.org/'>
+<img alt='W3C' height='48' src='https://www.w3.org/Icons/w3c_home' width='72' />
+</a>
+</p>
+<h1 class='title p-name' id='title' property='dc:title'>
+JSON-LD 1.1 Processor Conformance
+</h1>
+<h2 class='subtitle'>
+EARL results from the JSON-LD 1.1 Test Suite
+</h2>
+<h2 id='w3c-document-28-october-2015'>
+<time class='dt-published' datetime='2020-03-25' property='dc:issued'>
+25 March 2020
+</time>
+</h2>
+<dl>
+<dt>Editor:</dt><dd inlist='inlist' property='bibo:editor'><span typeof='foaf:Person'><meta content='Ruben Taelman' property='foaf:name' /><a href='https://www.rubensworks.net/' property='foaf:homepage'>Ruben Taelman</a></span></dd></dl>
+<p>
+This document is also available in these non-normative formats:
+<a href='earl.jsonld' re='alternate'>JSON-LD</a>
+.
+</p>
+<p class='copyright'>
+<a href='http://www.w3.org/Consortium/Legal/ipr-notice#Copyright'>
+Copyright
+</a>
+© 2010-2019
+<a href='http://www.w3.org/'>
+<sup>®</sup>
+</a>
+(<a href='http://www.csail.mit.edu/'><abbr title='Massachusetts Institute of Technology'>MIT</abbr></a>, <a href='http://www.ercim.eu/'><abbr title='European Research Consortium for Informatics and Mathematics'>ERCIM</abbr></a>, <a href='http://www.keio.ac.jp/'>Keio</a>, <a href='http://ev.buaa.edu.cn/'>Beihang</a>).
+<abbr title='World Wide Web Consortium'>W3C</abbr>
+<a href='http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer'>liability</a>
+,
+<a href='http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks'>trademark</a>
+and
+<a href='http://www.w3.org/Consortium/Legal/copyright-documents' rel='license'>document use</a>
+rules apply.
+</p>
+<hr />
+</div>
+<section id='abstract'>
+<h2>Abstract</h2>
+<p>
+This document report test subject conformance for and related specifications for
+<span property='doap:name'>Streaming JSON-LD 1.1 Test Suite</span>
+according to the requirements of the Evaluation and Report Language (EARL) 1.0 Schema
+[<a href='https://www.w3.org/TR/EARL10-Schema/'>EARL10-SCHEMA</a>].
+</p>
+<p>
+This report is also available in alternate formats:
+<a href='earl.jsonld'>
+JSON-LD
+</a>
+</p>
+</section>
+<section id='sodt'>
+<h2 id='h-sotd' resource='#h-sotd'>
+<span property='xhv:role' resource='xhv:heading'>
+Status of This Document
+</span>
+</h2>
+<p>
+This document is merely a <abbr title='World Wide Web Consortium'>W3C</abbr>-internal  document.
+It has no official standing of any kind and does not represent consensus of the
+<abbr title='World Wide Web Consortium'>W3C</abbr>
+Membership.
+</p>
+<p>
+This report describes the state of implementation conformance at the time of publication.
+</p>
+</section>
+<section id='toc'>
+<h2 class='introductory' id='h-toc' resource='#h-toc'>
+<span property='xhv:role' resource='xhv:heading'>
+Table of Contents
+</span>
+</h2>
+<ul class='toc' id='respecContents' role='directory'>
+<li class='tocline'>
+<a class='tocxref' href='#instructions-for-submitting-implementation-reports'>
+<span class='secno'>1.</span>
+Instructions for submitting implementation reports
+</a>
+</li>
+<li class='tocline'>
+<a class='tocxref' href='#test-manifests'>
+<span class='secno'>2.</span>
+Test Manifests
+</a>
+<ul class='toc'>
+<li class='tocline'>
+<span class='secno'>2.1</span>
+<a class='tocxref' href='#JSON-LD-Streaming-tests.'>
+JSON-LD Streaming tests.
+</a>
+</li>
+</ul>
+</li>
+<li class='tocline'>
+<a class='tocxref' href='#test-subjects'>
+<span class='secno'>A.</span>
+Test Subjects
+</a>
+<ul class='toc'>
+<li class='tocline'>
+<span class='secno'>A.1</span>
+<a class='tocxref' href='#subj_0'>jsonld-streaming-parser</a>
+</li>
+</ul>
+</li>
+<li class='tocline'>
+<a class='tocxref' href='#individual-test-results'>
+<span class='secno'>B.</span>
+Individual Test Results
+</a>
+</li>
+<li class='tocline'>
+<a class='tocxref' href='#test-definitions'>
+<span class='secno'>C.</span>
+Test Definitions
+</a>
+</li>
+<li class='tocline'>
+<a class='tocxref' href='#report-generation-software'>
+<span class='secno'>D.</span>
+Report Generation Software
+</a>
+</li>
+</ul>
+</section>
+<section id='instructions-for-submitting-implementation-reports'>
+<h2>Instructions for submitting implementation reports</h2>
+
+<p>Tests should be run using the test manifests defined in the
+  <a href="#test-manifests">Test Manifests</a> Section.</p>
+
+<p>The assumed base URI for the tests is <code>&lt;http://example/base/&gt;</code> if needed.</p>
+
+<p>Reports should be submitted in Turtle format to
+  <a href="mailto:public-json-ld-wg@w3.org">Public JSON-LD WG</a>
+  and include an <code>earl:Assertion</code>
+  for each test, referencing the test resource from the associated manifest
+  and the test subject being reported upon. An example test entry is be the following:</p>
+
+<pre><code>  [ a earl:Assertion;&#x000A;    earl:assertedBy &lt;--your-developer-identifier--&gt;;&#x000A;    earl:subject &lt;--your-software-identifier--&gt;;&#x000A;    earl:test &lt;--uri-of-test-from-manifest&gt;;&#x000A;    earl:result [&#x000A;      a earl:TestResult;&#x000A;      earl:outcome earl:passed;&#x000A;      dc:date &quot;2016-12-26T10:18:04-08:00&quot;^^xsd:dateTime];&#x000A;    earl:mode earl:automatic ] .&#x000A;</code></pre>
+
+<p>The Test Subject should be defined as a <code>doap:Project</code>, including the name,
+  homepage and developer(s) of the software (see <a href="https://github.com/edumbill/doap/wiki">DOAP</a>). Optionally, including the
+  project description and programming language. An example test subject description is the following:</p>
+
+<pre><code>  &lt;&gt; foaf:primaryTopic &lt;--your-software-identifier--&gt; ;&#x000A;    dc:issued &quot;2016-12-26T10:18:04-08:00&quot;^^xsd:dateTime ;&#x000A;    foaf:maker &lt;--your-developer-identifier--&gt; .&#x000A;&#x000A;  &lt;--your-software-identifier--&gt; a doap:Project, earl:TestSubject, earl:Software ;&#x000A;    doap:name          &quot;My Cool JSON-LD Parser&quot; ;&#x000A;    doap:revision      &quot;Software version number&quot; ;&#x000A;    doap:developer     &lt;--your-developer-identifier--&gt; ;&#x000A;    doap:homepage      &lt;--your-software-homepace--&gt; ;&#x000A;    doap:description   &quot;--your-project-description--&quot;@en ;&#x000A;    doap:programming-language &quot;--your-implementation-language--&quot; .&#x000A;</code></pre>
+
+<p>The software developer, either an organization or one or more individuals SHOULD be
+  referenced from <code>doap:developer</code> using <a href="http://xmlns.com/foaf/spec">FOAF</a>. For example:</p>
+
+<pre><code>  &lt;--your-developer-identifier--&gt; a foaf:Person, earl:Assertor;&#x000A;    foaf:name &quot;--My Name--&quot;;&#x000A;    foaf:homepage &lt;--my homepage--&gt; .&#x000A;</code></pre>
+</section>
+<section id='test-manifests'>
+<h2>
+<span class='secno'>2.</span>
+Test Manifests
+</h2>
+<section id='JSON-LD-Streaming-tests.'>
+<h2>
+<span class='secno'>2.1</span>
+<span>Streaming</span>
+</h2>
+<table class='report'>
+<tr>
+<th>
+Test
+</th>
+<th>
+<a href='#subj_0'>jsonld-streaming-parser</a>
+</th>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te001'>Test te001: @context must come before @id</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te002'>Test te002: @context must come before properties</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te003'>Test te003: @context must come before @type with context</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te004'>Test te004: @type with context must come before @id</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te005'>Test te005: @type with context must come before properties</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te006'>Test te006: Embedded @context must come before @id</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te007'>Test te007: Embedded @context must come before properties</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv001'>Test tv001: @context, @id and properties</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv002'>Test tv002: @context, blank @id and properties</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv003'>Test tv003: @context, implicit @id and properties</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv004'>Test tv004: Nested nodes</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv005'>Test tv005: Nested nodes and embedded context</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv006'>Test tv006: @context, @type-scoped context, @id, and other properties</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv007'>Test tv007: @context, plain @type, @id, and other properties</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv008'>Test tv008: No @context and @id</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv009'>Test tv009: Deeply nested nodes</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv010'>Test tv010: Deeply nested nodes without @id</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv011'>Test tv011: @id after properties</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv012'>Test tv012: No @id after properties</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv013'>Test tv013: @id after properties in nested node</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv014'>Test tv014: No @id after properties in nested node</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv015'>Test tv015: @id after properties in nested node with outer @id after node</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv016'>Test tv016: No @id after properties in nested node and no outer @id</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv017'>Test tv017: @id after @graph and properties</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv018'>Test tv018: No @id after @graph and properties</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv019'>Test tv019: @id after @graph and properties and late inner @id</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv020'>Test tv020: No @id after @graph and properties and late inner @id</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv021'>Test tv021: @id after @graph and properties and no @id</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr>
+<td>
+<a href='https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv022'>Test tv022: No @id after @graph and properties and no @id</a>
+</td>
+<td class='PASS'>
+PASS
+</td>
+</tr>
+<tr class='summary'>
+<td>
+Percentage passed out of 29 Tests
+</td>
+<td class='passed-all'>
+100.0%
+</td>
+</tr>
+</table>
+</section>
+</section>
+<section class='appendix' id='test-subjects'>
+<h2>
+<span class='secno'>A.</span>
+Test Subjects
+</h2>
+<p>
+This report was tested using the following test subjects:
+</p>
+<dl>
+<dt id='subj_0'>
+<span class='secno'>A.1</span>
+<a href='https://www.npmjs.com/package/jsonld-streaming-parser/'>
+<span about='https://www.npmjs.com/package/jsonld-streaming-parser/' property='doap:name'>jsonld-streaming-parser</span>
+</a>
+</dt>
+<dd>
+<dl>
+<dt>Description</dt>
+<dd lang='en' property='doap:description'>Streaming JSON-LD parser</dd>
+<dt>Release</dt>
+<dd property='doap:release'><span property='doap:revision'>unknown</span></dd>
+<dt>Programming Language</dt>
+<dd property='doap:programming-language'>JavaScript</dd>
+<dt>Home Page</dt>
+<dd>
+<a href='https://github.com/rubensworks/jsonld-streaming-parser.js#readme' property='doap:homepage'>
+https://github.com/rubensworks/jsonld-streaming-parser.js#readme
+</a>
+</dd>
+<dt>Developer</dt>
+<dd rel='doap:developer'>
+<div>
+<a href='https://www.rubensworks.net/#me'>
+<span property='foaf:name'>Ruben Taelman &lt;rubensworks@gmail.com&gt;</span>
+</a>
+<a href='https://www.rubensworks.net/' property='foaf:homepage'>
+https://www.rubensworks.net/
+</a>
+</div>
+</dd>
+<dt>
+Test Suite Compliance
+</dt>
+<dd>
+<table class='report'>
+<tbody>
+<tr>
+<td>
+Streaming
+</td>
+<td class='passed-all'>
+29/29 (100.0%)
+</td>
+</tr>
+</tbody>
+</table>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+<section class='appendix' id='individual-test-results' rel='xhv:related earl:assertions'>
+<h2>
+<span class='secno'>B.</span>
+Individual Test Results
+</h2>
+<p>
+Individual test results used to construct this report are available here:
+</p>
+<ul>
+<li>
+<a class='source' href='jsonld-streaming-parser-earl.ttl'>jsonld-streaming-parser-earl.ttl</a>
+</li>
+</ul>
+</section>
+<section class='appendix' id='report-generation-software' property='earl:generatedBy' resource='http://rubygems.org/gems/earl-report' typeof='Software doap:Project'>
+<h2>
+<span class='secno'>D.</span>
+Report Generation Software
+</h2>
+<p>
+This report generated by
+<span property='doap:name'><a href='http://rubygems.org/gems/earl-report'>earl-report</a></span>
+<meta content='Earl Report summary generator' property='doap:shortdesc' />
+<meta content='EarlReport generates HTML+RDFa rollups of multiple EARL reports' property='doap:description' />
+version
+<span property='doap:release' resource='https://github.com/gkellogg/earl-report/tree/0.4.9' typeof='doap:Version'>
+<span property='doap:revision'>0.4.9</span>
+<meta content='earl-report-0.4.9' property='doap:name' />
+<meta datatype='xsd:date' property='doap:created' />
+</span>
+an
+<a href='http://unlicense.org' property='doap:license'>Unlicensed</a>
+<span property='doap:programming-language'>Ruby</span>
+application. More information is available at
+<a href='https://github.com/gkellogg/earl-report' property='doap:homepage'>https://github.com/gkellogg/earl-report</a>
+.
+</p>
+<p property='doap:developer' resource='http://greggkellogg.net/foaf#me' typeof='foaf:Person'>
+This software is provided by
+<a href='http://greggkellogg.net/' property='foaf:homepage'><span about='http://greggkellogg.net/foaf#me' property='foaf:name'>Gregg Kellogg</span></a>
+in hopes that it might make the lives of conformance testers easier.
+</p>
+</section>
+</body>
+</html>

--- a/reports/jsonld-streaming-parser-earl.ttl
+++ b/reports/jsonld-streaming-parser-earl.ttl
@@ -9,7 +9,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
 
 <> foaf:primaryTopic <https://www.npmjs.com/package/jsonld-streaming-parser/>;
-    dc:issued "2020-03-24T18:33:20.672Z"^^xsd:dateTime;
+    dc:issued "2020-03-25T14:19:46.507Z"^^xsd:dateTime;
     foaf:maker <https://www.rubensworks.net/#me>.
 <https://www.npmjs.com/package/jsonld-streaming-parser/> a earl:Software, earl:TestSubject, doap:Project;
     doap:name "jsonld-streaming-parser";
@@ -44,8 +44,8 @@ _:assertion0 a earl:Assertion;
     earl:mode earl:automatic;
     earl:result _:result0.
 _:result0 a earl:TestResult;
-    earl:outcome earl:failed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    earl:outcome earl:passed;
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te002> a earl:TestCriterion, earl:TestCase;
     dc:title "@context must come before properties";
     dc:description "Generate an error if @context comes after properties";
@@ -59,8 +59,8 @@ _:assertion1 a earl:Assertion;
     earl:mode earl:automatic;
     earl:result _:result1.
 _:result1 a earl:TestResult;
-    earl:outcome earl:failed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    earl:outcome earl:passed;
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te003> a earl:TestCriterion, earl:TestCase;
     dc:title "@context must come before @type with context";
     dc:description "Generate an error if @context comes after @type with a type-scoped context";
@@ -74,8 +74,8 @@ _:assertion2 a earl:Assertion;
     earl:mode earl:automatic;
     earl:result _:result2.
 _:result2 a earl:TestResult;
-    earl:outcome earl:failed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    earl:outcome earl:passed;
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te004> a earl:TestCriterion, earl:TestCase;
     dc:title "@type with context must come before @id";
     dc:description "Generate an error if @type with context comes after @id";
@@ -89,8 +89,8 @@ _:assertion3 a earl:Assertion;
     earl:mode earl:automatic;
     earl:result _:result3.
 _:result3 a earl:TestResult;
-    earl:outcome earl:failed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    earl:outcome earl:passed;
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te005> a earl:TestCriterion, earl:TestCase;
     dc:title "@type with context must come before properties";
     dc:description "Generate an error if @type with context comes after properties";
@@ -104,8 +104,8 @@ _:assertion4 a earl:Assertion;
     earl:mode earl:automatic;
     earl:result _:result4.
 _:result4 a earl:TestResult;
-    earl:outcome earl:failed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    earl:outcome earl:passed;
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te006> a earl:TestCriterion, earl:TestCase;
     dc:title "Embedded @context must come before @id";
     dc:description "Generate an error if embedded @context comes after @id";
@@ -119,8 +119,8 @@ _:assertion5 a earl:Assertion;
     earl:mode earl:automatic;
     earl:result _:result5.
 _:result5 a earl:TestResult;
-    earl:outcome earl:failed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    earl:outcome earl:passed;
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te007> a earl:TestCriterion, earl:TestCase;
     dc:title "Embedded @context must come before properties";
     dc:description "Generate an error if embedded @context comes after properties";
@@ -134,8 +134,8 @@ _:assertion6 a earl:Assertion;
     earl:mode earl:automatic;
     earl:result _:result6.
 _:result6 a earl:TestResult;
-    earl:outcome earl:failed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    earl:outcome earl:passed;
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv001> a earl:TestCriterion, earl:TestCase;
     dc:title "@context, @id and properties";
     dc:description "@context, @id and properties";
@@ -150,7 +150,7 @@ _:assertion7 a earl:Assertion;
     earl:result _:result7.
 _:result7 a earl:TestResult;
     earl:outcome earl:passed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv002> a earl:TestCriterion, earl:TestCase;
     dc:title "@context, blank @id and properties";
     dc:description "@context, blank @id and properties";
@@ -165,7 +165,7 @@ _:assertion8 a earl:Assertion;
     earl:result _:result8.
 _:result8 a earl:TestResult;
     earl:outcome earl:passed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv003> a earl:TestCriterion, earl:TestCase;
     dc:title "@context, implicit @id and properties";
     dc:description "@context, implicit @id and properties";
@@ -180,7 +180,7 @@ _:assertion9 a earl:Assertion;
     earl:result _:result9.
 _:result9 a earl:TestResult;
     earl:outcome earl:passed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv004> a earl:TestCriterion, earl:TestCase;
     dc:title "Nested nodes";
     dc:description "Nested nodes";
@@ -195,7 +195,7 @@ _:assertion10 a earl:Assertion;
     earl:result _:result10.
 _:result10 a earl:TestResult;
     earl:outcome earl:passed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv005> a earl:TestCriterion, earl:TestCase;
     dc:title "Nested nodes and embedded context";
     dc:description "Nested nodes and embedded context";
@@ -210,7 +210,7 @@ _:assertion11 a earl:Assertion;
     earl:result _:result11.
 _:result11 a earl:TestResult;
     earl:outcome earl:passed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv006> a earl:TestCriterion, earl:TestCase;
     dc:title "@context, @type-scoped context, @id, and other properties";
     dc:description "@context, @type-scoped context, @id, and other properties";
@@ -225,7 +225,7 @@ _:assertion12 a earl:Assertion;
     earl:result _:result12.
 _:result12 a earl:TestResult;
     earl:outcome earl:passed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv007> a earl:TestCriterion, earl:TestCase;
     dc:title "@context, plain @type, @id, and other properties";
     dc:description "@type without an attached context may appear anywhere";
@@ -240,7 +240,7 @@ _:assertion13 a earl:Assertion;
     earl:result _:result13.
 _:result13 a earl:TestResult;
     earl:outcome earl:passed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv008> a earl:TestCriterion, earl:TestCase;
     dc:title "No @context and @id";
     dc:description "@context and @id are not required";
@@ -255,7 +255,7 @@ _:assertion14 a earl:Assertion;
     earl:result _:result14.
 _:result14 a earl:TestResult;
     earl:outcome earl:passed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv009> a earl:TestCriterion, earl:TestCase;
     dc:title "Deeply nested nodes";
     dc:description "Deeply nested nodes";
@@ -270,7 +270,7 @@ _:assertion15 a earl:Assertion;
     earl:result _:result15.
 _:result15 a earl:TestResult;
     earl:outcome earl:passed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv010> a earl:TestCriterion, earl:TestCase;
     dc:title "Deeply nested nodes without @id";
     dc:description "Deeply nested nodes without @id";
@@ -285,7 +285,7 @@ _:assertion16 a earl:Assertion;
     earl:result _:result16.
 _:result16 a earl:TestResult;
     earl:outcome earl:passed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv011> a earl:TestCriterion, earl:TestCase;
     dc:title "@id after properties";
     dc:description "Properties should be buffered until @id is encountered";
@@ -300,7 +300,7 @@ _:assertion17 a earl:Assertion;
     earl:result _:result17.
 _:result17 a earl:TestResult;
     earl:outcome earl:passed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv012> a earl:TestCriterion, earl:TestCase;
     dc:title "No @id after properties";
     dc:description "Properties should be buffered until node closes";
@@ -315,7 +315,7 @@ _:assertion18 a earl:Assertion;
     earl:result _:result18.
 _:result18 a earl:TestResult;
     earl:outcome earl:passed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv013> a earl:TestCriterion, earl:TestCase;
     dc:title "@id after properties in nested node";
     dc:description "Properties in nested node should be buffered until @id is encountered";
@@ -330,7 +330,7 @@ _:assertion19 a earl:Assertion;
     earl:result _:result19.
 _:result19 a earl:TestResult;
     earl:outcome earl:passed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv014> a earl:TestCriterion, earl:TestCase;
     dc:title "No @id after properties in nested node";
     dc:description "Properties in nested node should be buffered until node closes";
@@ -345,7 +345,7 @@ _:assertion20 a earl:Assertion;
     earl:result _:result20.
 _:result20 a earl:TestResult;
     earl:outcome earl:passed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv015> a earl:TestCriterion, earl:TestCase;
     dc:title "@id after properties in nested node with outer @id after node";
     dc:description "Properties in nested node with @id after node should be buffered until @id is encountered";
@@ -360,7 +360,7 @@ _:assertion21 a earl:Assertion;
     earl:result _:result21.
 _:result21 a earl:TestResult;
     earl:outcome earl:passed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv016> a earl:TestCriterion, earl:TestCase;
     dc:title "No @id after properties in nested node and no outer @id";
     dc:description "Properties in nested node and no outer @id should be buffered until node closes";
@@ -375,7 +375,7 @@ _:assertion22 a earl:Assertion;
     earl:result _:result22.
 _:result22 a earl:TestResult;
     earl:outcome earl:passed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv017> a earl:TestCriterion, earl:TestCase;
     dc:title "@id after @graph and properties";
     dc:description "Properties with @graph should be buffered until @id is encountered";
@@ -390,7 +390,7 @@ _:assertion23 a earl:Assertion;
     earl:result _:result23.
 _:result23 a earl:TestResult;
     earl:outcome earl:passed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv018> a earl:TestCriterion, earl:TestCase;
     dc:title "No @id after @graph and properties";
     dc:description "Properties with @graph should be buffered until node closes";
@@ -405,7 +405,7 @@ _:assertion24 a earl:Assertion;
     earl:result _:result24.
 _:result24 a earl:TestResult;
     earl:outcome earl:passed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv019> a earl:TestCriterion, earl:TestCase;
     dc:title "@id after @graph and properties and late inner @id";
     dc:description "Properties with @graph should be buffered until @id is encountered";
@@ -420,7 +420,7 @@ _:assertion25 a earl:Assertion;
     earl:result _:result25.
 _:result25 a earl:TestResult;
     earl:outcome earl:passed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv020> a earl:TestCriterion, earl:TestCase;
     dc:title "No @id after @graph and properties and late inner @id";
     dc:description "Properties with @graph should be buffered until node closes and @id is encountered";
@@ -435,7 +435,7 @@ _:assertion26 a earl:Assertion;
     earl:result _:result26.
 _:result26 a earl:TestResult;
     earl:outcome earl:passed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv021> a earl:TestCriterion, earl:TestCase;
     dc:title "@id after @graph and properties and no @id";
     dc:description "Properties with @graph should be buffered until node closes and @id is encountered";
@@ -450,7 +450,7 @@ _:assertion27 a earl:Assertion;
     earl:result _:result27.
 _:result27 a earl:TestResult;
     earl:outcome earl:passed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.
 <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv022> a earl:TestCriterion, earl:TestCase;
     dc:title "No @id after @graph and properties and no @id";
     dc:description "Properties with @graph should be buffered until nodes close";
@@ -465,4 +465,4 @@ _:assertion28 a earl:Assertion;
     earl:result _:result28.
 _:result28 a earl:TestResult;
     earl:outcome earl:passed;
-    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+    dc:date "2020-03-25T14:19:46.507Z"^^xsd:dateTime.

--- a/reports/jsonld-streaming-parser-earl.ttl
+++ b/reports/jsonld-streaming-parser-earl.ttl
@@ -1,0 +1,468 @@
+@prefix dc: <http://purl.org/dc/terms/>.
+@prefix doap: <http://usefulinc.com/ns/doap#>.
+@prefix earl: <http://www.w3.org/ns/earl#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix rdft: <http://www.w3.org/ns/rdftest#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<> foaf:primaryTopic <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    dc:issued "2020-03-24T18:33:20.672Z"^^xsd:dateTime;
+    foaf:maker <https://www.rubensworks.net/#me>.
+<https://www.npmjs.com/package/jsonld-streaming-parser/> a earl:Software, earl:TestSubject, doap:Project;
+    doap:name "jsonld-streaming-parser";
+    dc:title "jsonld-streaming-parser";
+    doap:homepage <https://github.com/rubensworks/jsonld-streaming-parser.js#readme>;
+    doap:license <http://opensource.org/licenses/MIT>;
+    doap:programming-language "JavaScript";
+    doap:implements <https://www.w3.org/TR/json-ld/>;
+    doap:category <http://dbpedia.org/resource/Resource_Description_Framework>;
+    doap:download-page <https://npmjs.org/package/jsonld-streaming-parser>;
+    doap:bug-database <https://github.com/rubensworks/jsonld-streaming-parser.js/issues>;
+    doap:developer <https://www.rubensworks.net/#me>;
+    doap:maintainer <https://www.rubensworks.net/#me>;
+    doap:documenter <https://www.rubensworks.net/#me>;
+    doap:maker <https://www.rubensworks.net/#me>;
+    dc:creator <https://www.rubensworks.net/#me>;
+    dc:description "Streaming JSON-LD parser"@en;
+    doap:description "Streaming JSON-LD parser"@en.
+<https://www.rubensworks.net/#me> a foaf:Person, earl:Assertor;
+    foaf:name "Ruben Taelman <rubensworks@gmail.com>";
+    foaf:homepage <https://www.rubensworks.net/>.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te001> a earl:TestCriterion, earl:TestCase;
+    dc:title "@context must come before @id";
+    dc:description "Generate an error if @context comes after @id";
+    earl:assertions _:assertions0.
+_:assertions0 rdf:first _:assertion0;
+    rdf:rest rdf:nil.
+_:assertion0 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te001>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result0.
+_:result0 a earl:TestResult;
+    earl:outcome earl:failed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te002> a earl:TestCriterion, earl:TestCase;
+    dc:title "@context must come before properties";
+    dc:description "Generate an error if @context comes after properties";
+    earl:assertions _:assertions1.
+_:assertions1 rdf:first _:assertion1;
+    rdf:rest rdf:nil.
+_:assertion1 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te002>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result1.
+_:result1 a earl:TestResult;
+    earl:outcome earl:failed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te003> a earl:TestCriterion, earl:TestCase;
+    dc:title "@context must come before @type with context";
+    dc:description "Generate an error if @context comes after @type with a type-scoped context";
+    earl:assertions _:assertions2.
+_:assertions2 rdf:first _:assertion2;
+    rdf:rest rdf:nil.
+_:assertion2 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te003>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result2.
+_:result2 a earl:TestResult;
+    earl:outcome earl:failed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te004> a earl:TestCriterion, earl:TestCase;
+    dc:title "@type with context must come before @id";
+    dc:description "Generate an error if @type with context comes after @id";
+    earl:assertions _:assertions3.
+_:assertions3 rdf:first _:assertion3;
+    rdf:rest rdf:nil.
+_:assertion3 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te004>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result3.
+_:result3 a earl:TestResult;
+    earl:outcome earl:failed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te005> a earl:TestCriterion, earl:TestCase;
+    dc:title "@type with context must come before properties";
+    dc:description "Generate an error if @type with context comes after properties";
+    earl:assertions _:assertions4.
+_:assertions4 rdf:first _:assertion4;
+    rdf:rest rdf:nil.
+_:assertion4 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te005>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result4.
+_:result4 a earl:TestResult;
+    earl:outcome earl:failed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te006> a earl:TestCriterion, earl:TestCase;
+    dc:title "Embedded @context must come before @id";
+    dc:description "Generate an error if embedded @context comes after @id";
+    earl:assertions _:assertions5.
+_:assertions5 rdf:first _:assertion5;
+    rdf:rest rdf:nil.
+_:assertion5 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te006>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result5.
+_:result5 a earl:TestResult;
+    earl:outcome earl:failed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te007> a earl:TestCriterion, earl:TestCase;
+    dc:title "Embedded @context must come before properties";
+    dc:description "Generate an error if embedded @context comes after properties";
+    earl:assertions _:assertions6.
+_:assertions6 rdf:first _:assertion6;
+    rdf:rest rdf:nil.
+_:assertion6 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te007>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result6.
+_:result6 a earl:TestResult;
+    earl:outcome earl:failed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv001> a earl:TestCriterion, earl:TestCase;
+    dc:title "@context, @id and properties";
+    dc:description "@context, @id and properties";
+    earl:assertions _:assertions7.
+_:assertions7 rdf:first _:assertion7;
+    rdf:rest rdf:nil.
+_:assertion7 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv001>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result7.
+_:result7 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv002> a earl:TestCriterion, earl:TestCase;
+    dc:title "@context, blank @id and properties";
+    dc:description "@context, blank @id and properties";
+    earl:assertions _:assertions8.
+_:assertions8 rdf:first _:assertion8;
+    rdf:rest rdf:nil.
+_:assertion8 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv002>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result8.
+_:result8 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv003> a earl:TestCriterion, earl:TestCase;
+    dc:title "@context, implicit @id and properties";
+    dc:description "@context, implicit @id and properties";
+    earl:assertions _:assertions9.
+_:assertions9 rdf:first _:assertion9;
+    rdf:rest rdf:nil.
+_:assertion9 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv003>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result9.
+_:result9 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv004> a earl:TestCriterion, earl:TestCase;
+    dc:title "Nested nodes";
+    dc:description "Nested nodes";
+    earl:assertions _:assertions10.
+_:assertions10 rdf:first _:assertion10;
+    rdf:rest rdf:nil.
+_:assertion10 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv004>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result10.
+_:result10 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv005> a earl:TestCriterion, earl:TestCase;
+    dc:title "Nested nodes and embedded context";
+    dc:description "Nested nodes and embedded context";
+    earl:assertions _:assertions11.
+_:assertions11 rdf:first _:assertion11;
+    rdf:rest rdf:nil.
+_:assertion11 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv005>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result11.
+_:result11 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv006> a earl:TestCriterion, earl:TestCase;
+    dc:title "@context, @type-scoped context, @id, and other properties";
+    dc:description "@context, @type-scoped context, @id, and other properties";
+    earl:assertions _:assertions12.
+_:assertions12 rdf:first _:assertion12;
+    rdf:rest rdf:nil.
+_:assertion12 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv006>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result12.
+_:result12 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv007> a earl:TestCriterion, earl:TestCase;
+    dc:title "@context, plain @type, @id, and other properties";
+    dc:description "@type without an attached context may appear anywhere";
+    earl:assertions _:assertions13.
+_:assertions13 rdf:first _:assertion13;
+    rdf:rest rdf:nil.
+_:assertion13 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv007>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result13.
+_:result13 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv008> a earl:TestCriterion, earl:TestCase;
+    dc:title "No @context and @id";
+    dc:description "@context and @id are not required";
+    earl:assertions _:assertions14.
+_:assertions14 rdf:first _:assertion14;
+    rdf:rest rdf:nil.
+_:assertion14 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv008>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result14.
+_:result14 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv009> a earl:TestCriterion, earl:TestCase;
+    dc:title "Deeply nested nodes";
+    dc:description "Deeply nested nodes";
+    earl:assertions _:assertions15.
+_:assertions15 rdf:first _:assertion15;
+    rdf:rest rdf:nil.
+_:assertion15 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv009>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result15.
+_:result15 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv010> a earl:TestCriterion, earl:TestCase;
+    dc:title "Deeply nested nodes without @id";
+    dc:description "Deeply nested nodes without @id";
+    earl:assertions _:assertions16.
+_:assertions16 rdf:first _:assertion16;
+    rdf:rest rdf:nil.
+_:assertion16 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv010>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result16.
+_:result16 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv011> a earl:TestCriterion, earl:TestCase;
+    dc:title "@id after properties";
+    dc:description "Properties should be buffered until @id is encountered";
+    earl:assertions _:assertions17.
+_:assertions17 rdf:first _:assertion17;
+    rdf:rest rdf:nil.
+_:assertion17 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv011>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result17.
+_:result17 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv012> a earl:TestCriterion, earl:TestCase;
+    dc:title "No @id after properties";
+    dc:description "Properties should be buffered until node closes";
+    earl:assertions _:assertions18.
+_:assertions18 rdf:first _:assertion18;
+    rdf:rest rdf:nil.
+_:assertion18 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv012>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result18.
+_:result18 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv013> a earl:TestCriterion, earl:TestCase;
+    dc:title "@id after properties in nested node";
+    dc:description "Properties in nested node should be buffered until @id is encountered";
+    earl:assertions _:assertions19.
+_:assertions19 rdf:first _:assertion19;
+    rdf:rest rdf:nil.
+_:assertion19 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv013>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result19.
+_:result19 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv014> a earl:TestCriterion, earl:TestCase;
+    dc:title "No @id after properties in nested node";
+    dc:description "Properties in nested node should be buffered until node closes";
+    earl:assertions _:assertions20.
+_:assertions20 rdf:first _:assertion20;
+    rdf:rest rdf:nil.
+_:assertion20 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv014>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result20.
+_:result20 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv015> a earl:TestCriterion, earl:TestCase;
+    dc:title "@id after properties in nested node with outer @id after node";
+    dc:description "Properties in nested node with @id after node should be buffered until @id is encountered";
+    earl:assertions _:assertions21.
+_:assertions21 rdf:first _:assertion21;
+    rdf:rest rdf:nil.
+_:assertion21 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv015>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result21.
+_:result21 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv016> a earl:TestCriterion, earl:TestCase;
+    dc:title "No @id after properties in nested node and no outer @id";
+    dc:description "Properties in nested node and no outer @id should be buffered until node closes";
+    earl:assertions _:assertions22.
+_:assertions22 rdf:first _:assertion22;
+    rdf:rest rdf:nil.
+_:assertion22 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv016>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result22.
+_:result22 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv017> a earl:TestCriterion, earl:TestCase;
+    dc:title "@id after @graph and properties";
+    dc:description "Properties with @graph should be buffered until @id is encountered";
+    earl:assertions _:assertions23.
+_:assertions23 rdf:first _:assertion23;
+    rdf:rest rdf:nil.
+_:assertion23 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv017>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result23.
+_:result23 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv018> a earl:TestCriterion, earl:TestCase;
+    dc:title "No @id after @graph and properties";
+    dc:description "Properties with @graph should be buffered until node closes";
+    earl:assertions _:assertions24.
+_:assertions24 rdf:first _:assertion24;
+    rdf:rest rdf:nil.
+_:assertion24 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv018>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result24.
+_:result24 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv019> a earl:TestCriterion, earl:TestCase;
+    dc:title "@id after @graph and properties and late inner @id";
+    dc:description "Properties with @graph should be buffered until @id is encountered";
+    earl:assertions _:assertions25.
+_:assertions25 rdf:first _:assertion25;
+    rdf:rest rdf:nil.
+_:assertion25 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv019>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result25.
+_:result25 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv020> a earl:TestCriterion, earl:TestCase;
+    dc:title "No @id after @graph and properties and late inner @id";
+    dc:description "Properties with @graph should be buffered until node closes and @id is encountered";
+    earl:assertions _:assertions26.
+_:assertions26 rdf:first _:assertion26;
+    rdf:rest rdf:nil.
+_:assertion26 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv020>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result26.
+_:result26 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv021> a earl:TestCriterion, earl:TestCase;
+    dc:title "@id after @graph and properties and no @id";
+    dc:description "Properties with @graph should be buffered until node closes and @id is encountered";
+    earl:assertions _:assertions27.
+_:assertions27 rdf:first _:assertion27;
+    rdf:rest rdf:nil.
+_:assertion27 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv021>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result27.
+_:result27 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv022> a earl:TestCriterion, earl:TestCase;
+    dc:title "No @id after @graph and properties and no @id";
+    dc:description "Properties with @graph should be buffered until nodes close";
+    earl:assertions _:assertions28.
+_:assertions28 rdf:first _:assertion28;
+    rdf:rest rdf:nil.
+_:assertion28 a earl:Assertion;
+    earl:assertedBy <https://www.rubensworks.net/#me>;
+    earl:test <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv022>;
+    earl:subject <https://www.npmjs.com/package/jsonld-streaming-parser/>;
+    earl:mode earl:automatic;
+    earl:result _:result28.
+_:result28 a earl:TestResult;
+    earl:outcome earl:passed;
+    dc:date "2020-03-24T18:33:20.672Z"^^xsd:dateTime.

--- a/reports/manifests.nt
+++ b/reports/manifests.nt
@@ -1,0 +1,237 @@
+_:g70340103310620 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv009> .
+_:g70340103310620 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340095064820 .
+_:g70340094651400 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te002> .
+_:g70340094651400 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340094741560 .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv006> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv006> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv006> <http://www.w3.org/2000/01/rdf-schema#comment> "@context, @type-scoped context, @id, and other properties" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv006> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "@context, @type-scoped context, @id, and other properties" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv006> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv006-out.nq> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv006> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv006-in.jsonld> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv018> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv018> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv018> <http://www.w3.org/2000/01/rdf-schema#comment> "Properties with @graph should be buffered until node closes" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv018> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "No @id after @graph and properties" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv018> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv018-out.nq> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv018> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv018-in.jsonld> .
+_:g70340094681240 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te001> .
+_:g70340094681240 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340094651400 .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv010> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv010> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv010> <http://www.w3.org/2000/01/rdf-schema#comment> "Deeply nested nodes without @id" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv010> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Deeply nested nodes without @id" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv010> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv010-out.nq> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv010> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv010-in.jsonld> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv001> <http://www.w3.org/2000/01/rdf-schema#comment> "@context, @id and properties" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv001> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "@context, @id and properties" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv001> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv001-out.nq> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv001> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv001-in.jsonld> .
+_:g70340094419460 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te006> .
+_:g70340094419460 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340094289460 .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te007> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te007> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te007> <http://www.w3.org/2000/01/rdf-schema#comment> "Generate an error if embedded @context comes after properties" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te007> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded @context must come before properties" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te007> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid streaming key order" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te007> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/e007-in.jsonld> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te006> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te006> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te006> <http://www.w3.org/2000/01/rdf-schema#comment> "Generate an error if embedded @context comes after @id" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te006> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Embedded @context must come before @id" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te006> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid streaming key order" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te006> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/e006-in.jsonld> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te004> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te004> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te004> <http://www.w3.org/2000/01/rdf-schema#comment> "Generate an error if @type with context comes after @id" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te004> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "@type with context must come before @id" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te004> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid streaming key order" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te004> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/e004-in.jsonld> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#Manifest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest> <http://www.w3.org/2000/01/rdf-schema#comment> "JSON-LD Streaming tests." .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest> <https://w3c.github.io/json-ld-api/tests/vocab#baseIri> "https://w3c.github.io/json-ld-streaming/tests/" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Streaming" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#entries> _:g70340094681240 .
+_:g70340103346440 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv012> .
+_:g70340103346440 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340103290380 .
+_:g70340094479140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv011> .
+_:g70340094479140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340103346440 .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te002> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te002> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te002> <http://www.w3.org/2000/01/rdf-schema#comment> "Generate an error if @context comes after properties" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te002> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "@context must come before properties" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te002> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid streaming key order" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te002> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/e002-in.jsonld> .
+_:g70340094289460 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te007> .
+_:g70340094289460 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340094109360 .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te001> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te001> <http://www.w3.org/2000/01/rdf-schema#comment> "Generate an error if @context comes after @id" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te001> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "@context must come before @id" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te001> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid streaming key order" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te001> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/e001-in.jsonld> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv008> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv008> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv008> <http://www.w3.org/2000/01/rdf-schema#comment> "@context and @id are not required" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv008> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "No @context and @id" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv008> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv008-out.nq> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv008> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv008-in.jsonld> .
+_:g70340105696300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv002> .
+_:g70340105696300 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340093853840 .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv002> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv002> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv002> <http://www.w3.org/2000/01/rdf-schema#comment> "@context, blank @id and properties" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv002> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "@context, blank @id and properties" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv002> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv002-out.nq> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv002> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv002-in.jsonld> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te003> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te003> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te003> <http://www.w3.org/2000/01/rdf-schema#comment> "Generate an error if @context comes after @type with a type-scoped context" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te003> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "@context must come before @type with context" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te003> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid streaming key order" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te003> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/e003-in.jsonld> .
+_:g70340094741560 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te003> .
+_:g70340094741560 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340094641560 .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv005> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv005> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv005> <http://www.w3.org/2000/01/rdf-schema#comment> "Nested nodes and embedded context" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv005> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Nested nodes and embedded context" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv005> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv005-out.nq> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv005> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv005-in.jsonld> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv020> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv020> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv020> <http://www.w3.org/2000/01/rdf-schema#comment> "Properties with @graph should be buffered until node closes and @id is encountered" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv020> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "No @id after @graph and properties and late inner @id" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv020> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv020-out.nq> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv020> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv020-in.jsonld> .
+_:g70340094557740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te005> .
+_:g70340094557740 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340094419460 .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv007> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv007> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv007> <http://www.w3.org/2000/01/rdf-schema#comment> "@type without an attached context may appear anywhere" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv007> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "@context, plain @type, @id, and other properties" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv007> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv007-out.nq> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv007> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv007-in.jsonld> .
+_:g70340094641560 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te004> .
+_:g70340094641560 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340094557740 .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te005> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#NegativeEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te005> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te005> <http://www.w3.org/2000/01/rdf-schema#comment> "Generate an error if @type with context comes after properties" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te005> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "@type with context must come before properties" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te005> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> "invalid streaming key order" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#te005> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/e005-in.jsonld> .
+_:g70340103238760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv015> .
+_:g70340103238760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340105913660 .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv016> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv016> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv016> <http://www.w3.org/2000/01/rdf-schema#comment> "Properties in nested node and no outer @id should be buffered until node closes" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv016> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "No @id after properties in nested node and no outer @id" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv016> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv016-out.nq> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv016> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv016-in.jsonld> .
+_:g70340103214440 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv019> .
+_:g70340103214440 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340103120220 .
+_:g70340103218480 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv018> .
+_:g70340103218480 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340103214440 .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv012> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv012> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv012> <http://www.w3.org/2000/01/rdf-schema#comment> "Properties should be buffered until node closes" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv012> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "No @id after properties" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv012> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv012-out.nq> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv012> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv012-in.jsonld> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv022> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv022> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv022> <http://www.w3.org/2000/01/rdf-schema#comment> "Properties with @graph should be buffered until nodes close" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv022> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "No @id after @graph and properties and no @id" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv022> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv022-out.nq> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv022> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv022-in.jsonld> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv021> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv021> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv021> <http://www.w3.org/2000/01/rdf-schema#comment> "Properties with @graph should be buffered until node closes and @id is encountered" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv021> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "@id after @graph and properties and no @id" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv021> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv021-out.nq> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv021> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv021-in.jsonld> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv019> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv019> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv019> <http://www.w3.org/2000/01/rdf-schema#comment> "Properties with @graph should be buffered until @id is encountered" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv019> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "@id after @graph and properties and late inner @id" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv019> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv019-out.nq> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv019> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv019-in.jsonld> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv017> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv017> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv017> <http://www.w3.org/2000/01/rdf-schema#comment> "Properties with @graph should be buffered until @id is encountered" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv017> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "@id after @graph and properties" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv017> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv017-out.nq> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv017> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv017-in.jsonld> .
+_:g70340093664140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv004> .
+_:g70340093664140 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340093552760 .
+_:g70340103393700 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv007> .
+_:g70340103393700 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340103322240 .
+_:g70340094109360 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv001> .
+_:g70340094109360 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340105696300 .
+_:g70340093552760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv005> .
+_:g70340093552760 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340103427160 .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv015> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv015> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv015> <http://www.w3.org/2000/01/rdf-schema#comment> "Properties in nested node with @id after node should be buffered until @id is encountered" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv015> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "@id after properties in nested node with outer @id after node" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv015> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv015-out.nq> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv015> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv015-in.jsonld> .
+_:g70340102324920 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv022> .
+_:g70340102324920 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv004> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv004> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv004> <http://www.w3.org/2000/01/rdf-schema#comment> "Nested nodes" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv004> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Nested nodes" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv004> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv004-out.nq> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv004> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv004-in.jsonld> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv014> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv014> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv014> <http://www.w3.org/2000/01/rdf-schema#comment> "Properties in nested node should be buffered until node closes" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv014> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "No @id after properties in nested node" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv014> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv014-out.nq> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv014> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv014-in.jsonld> .
+_:g70340093853840 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv003> .
+_:g70340093853840 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340093664140 .
+_:g70340103120220 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv020> .
+_:g70340103120220 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340103205100 .
+_:g70340103243680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv014> .
+_:g70340103243680 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340103238760 .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv011> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv011> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv011> <http://www.w3.org/2000/01/rdf-schema#comment> "Properties should be buffered until @id is encountered" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv011> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "@id after properties" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv011> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv011-out.nq> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv011> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv011-in.jsonld> .
+_:g70340103290380 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv013> .
+_:g70340103290380 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340103243680 .
+_:g70340103322240 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv008> .
+_:g70340103322240 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340103310620 .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv003> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv003> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv003> <http://www.w3.org/2000/01/rdf-schema#comment> "@context, implicit @id and properties" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv003> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "@context, implicit @id and properties" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv003> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv003-out.nq> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv003> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv003-in.jsonld> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv013> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv013> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv013> <http://www.w3.org/2000/01/rdf-schema#comment> "Properties in nested node should be buffered until @id is encountered" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv013> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "@id after properties in nested node" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv013> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv013-out.nq> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv013> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv013-in.jsonld> .
+_:g70340103205100 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv021> .
+_:g70340103205100 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340102324920 .
+_:g70340103230380 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv017> .
+_:g70340103230380 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340103218480 .
+_:g70340103427160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv006> .
+_:g70340103427160 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340103393700 .
+_:g70340105913660 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv016> .
+_:g70340105913660 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340103230380 .
+_:g70340095064820 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv010> .
+_:g70340095064820 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:g70340094479140 .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv009> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#PositiveEvaluationTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv009> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3c.github.io/json-ld-api/tests/vocab#ToRDFTest> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv009> <http://www.w3.org/2000/01/rdf-schema#comment> "Deeply nested nodes" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv009> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#name> "Deeply nested nodes" .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv009> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#result> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv009-out.nq> .
+<https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest#tv009> <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#action> <https://w3c.github.io/json-ld-streaming/tests/stream-toRdf/tv009-in.jsonld> .

--- a/reports/template.haml
+++ b/reports/template.haml
@@ -1,0 +1,392 @@
+-# This template is used for generating a rollup EARL report. It expects to be
+-# called with a single _tests_ local with the following structure
+- require 'cgi'
+- require 'digest'
+- editors = [{ name: "Ruben Taelman", url: "https://www.rubensworks.net/"}]
+- foaf = {name: "Ruben Taelman", url: "https://www.rubensworks.net/#me" }
+
+!!! 5
+%html
+  - subjects = tests['testSubjects'].sort_by {|s| s['name'].to_s.downcase}
+  %head
+    %meta{"http-equiv" => "Content-Type", :content => "text/html;charset=utf-8"}
+    %link{rel: "alternate", href: "earl.jsonld"}
+    %link{rel: "stylesheet", href: "https://www.w3.org/StyleSheets/TR/base"}
+    - tests['assertions'].each do |file|
+      %link{rel: "related", href: file}
+    %title
+      Streaming JSON-LD 1.1 Processor Conformance
+    :css
+      span[property='dc:description rdfs:comment'] { display: none; }
+      td.PASS { color: green; }
+      td.FAIL { color: red; }
+      table.report {
+        border-width: 1px;
+        border-spacing: 2px;
+        border-style: outset;
+        border-color: gray;
+        border-collapse: separate;
+        background-color: white;
+      }
+      table.report th {
+        border-width: 1px;
+        padding: 1px;
+        border-style: inset;
+        border-color: gray;
+        background-color: white;
+        -moz-border-radius: ;
+      }
+      table.report td {
+        border-width: 1px;
+        padding: 1px;
+        border-style: inset;
+        border-color: gray;
+        background-color: white;
+        -moz-border-radius: ;
+      }
+      tr.summary {font-weight: bold;}
+      td.passed-all {color: green;}
+      td.passed-most {color: darkorange;}
+      td.passed-some {color: red;}
+      em.rfc2119 {
+        text-transform: lowercase;
+        font-variant:   small-caps;
+        font-style:     normal;
+        color:          #900;
+      }
+      a.testlink {
+        color: inherit;
+        text-decoration: none;
+      }
+      a.testlink:hover {
+        text-decoration: underline;
+      }
+      pre > code {
+        color: #C83500;
+      }
+  %body{prefix: "bibo: http://purl.org/ontology/bibo/ earl: http://www.w3.org/ns/earl# doap: http://usefulinc.com/ns/doap# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#", vocab: "http://www.w3.org/ns/earl#"}
+    - subject_refs = {}
+    - passed_tests = []
+    - tests['entries'].sort_by {|m| m['title'].to_s.downcase}.each {|m| m['title'] ||= m['rdfs:label'] || m['description'] || m['rdfs:comment']}
+    - subjects.each_with_index do |subject, index|
+      - subject_refs[subject['@id']] = "subj_#{index}"
+    %div.head{role: :contentinfo}
+      %p
+        %a{href: "http://www.w3.org/"}
+          %img{width: 72, height: 48, src: "https://www.w3.org/Icons/w3c_home", alt: "W3C"}
+      %h1.title.p-name#title{property: "dc:title"}
+        JSON-LD 1.1 Processor Conformance
+      %h2.subtitle
+        EARL results from the JSON-LD 1.1 Test Suite
+      %h2#w3c-document-28-october-2015
+        %time.dt-published{property: "dc:issued", datetime: Time.now.strftime('%Y-%m-%d')}
+          = Time.now.strftime("%d %B %Y")
+      %dl
+        %dt="Editor:"
+        - editors.each do |ed|
+          %dd{property: "bibo:editor", inlist: true}<>
+            %span{typeof: "foaf:Person"}<>
+              %meta{property: "foaf:name", content: ed[:name]}<>
+              %a{property: "foaf:homepage", href: ed[:url]}<>
+                = ed[:name]
+      %p
+        This document is also available in these non-normative formats:
+        %a{re: "alternate", href: "earl.jsonld"}="JSON-LD"
+        = "."
+      %p.copyright
+        %a{href: "http://www.w3.org/Consortium/Legal/ipr-notice#Copyright"}
+          Copyright
+        © 2010-2019
+        %a{href: "http://www.w3.org/"}
+          %sup="®"
+        (
+        %a{href: "http://www.csail.mit.edu/"}<>
+          %abbr{title: "Massachusetts Institute of Technology"}<>="MIT"
+        = ", "
+        %a{href: "http://www.ercim.eu/"}<>
+          %abbr{title: "European Research Consortium for Informatics and Mathematics"}<>="ERCIM"
+        = ", "
+        %a{href: "http://www.keio.ac.jp/"}<>="Keio"
+        = ", "
+        %a{href: "http://ev.buaa.edu.cn/"}<>="Beihang"
+        ).
+        %abbr{title: "World Wide Web Consortium"}="W3C"
+        %a{href: "http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer"}="liability"
+        = ","
+        %a{href: "http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks"}="trademark"
+        and
+        %a{rel: "license", href: "http://www.w3.org/Consortium/Legal/copyright-documents"}="document use"
+        rules apply.
+      %hr
+    %section#abstract
+      %h2="Abstract"
+      %p
+        This document report test subject conformance for and related specifications for
+        %span{property: "doap:name"}<="Streaming JSON-LD 1.1 Test Suite"
+        according to the requirements of the Evaluation and Report Language (EARL) 1.0 Schema
+        [
+        %a{href: "https://www.w3.org/TR/EARL10-Schema/"}<>="EARL10-SCHEMA"
+        ].
+      %p
+        This report is also available in alternate formats:
+        %a{href: "earl.jsonld"}
+          JSON-LD
+    %section#sodt
+      %h2#h-sotd{resource: "#h-sotd"}
+        %span{property: "xhv:role", resource: "xhv:heading"}
+          Status of This Document
+      %p
+        This document is merely a
+        = " "
+        %abbr{title: "World Wide Web Consortium"}<>="W3C"
+        ="-internal  document."
+        It has no official standing of any kind and does not represent consensus of the
+        %abbr{title: "World Wide Web Consortium"}="W3C"
+        Membership.
+      %p
+        This report describes the state of implementation conformance at the time of publication.
+    %section#toc
+      %h2.introductory#h-toc{resource: "#h-toc"}
+        %span{property: "xhv:role", resource: "xhv:heading"}
+          Table of Contents
+      %ul.toc#respecContents{role: "directory"}
+        %li.tocline
+          %a.tocxref{href: "#instructions-for-submitting-implementation-reports"}
+            %span.secno="1."
+            Instructions for submitting implementation reports
+        %li.tocline
+          %a.tocxref{href: "#test-manifests"}
+            %span.secno="2."
+            Test Manifests
+          %ul.toc
+            - tests['entries'].sort_by {|m| m['title'].to_s.downcase}.each_with_index do |manifest, ndx|
+              %li.tocline
+                %span.secno="2.#{ndx+1}"
+                %a.tocxref{href: "##{manifest['rdfs:comment'].gsub(' ', '-')}"}
+                  ~ manifest['rdfs:comment']
+        %li.tocline
+          %a.tocxref{href: "#test-subjects"}
+            %span.secno="A."
+            Test Subjects
+          %ul.toc
+            - subjects.each_with_index do |subject, ndx|
+              %li.tocline
+                %span.secno="A.#{ndx+1}"
+                %a.tocxref{href: "#" + subject_refs[subject['@id']]}= subject['name']
+        %li.tocline
+          %a.tocxref{href: "#individual-test-results"}
+            %span.secno="B."
+            Individual Test Results
+        %li.tocline
+          %a.tocxref{href: "#test-definitions"}
+            %span.secno="C."
+            Test Definitions
+        %li.tocline
+          %a.tocxref{href: "#report-generation-software"}
+            %span.secno="D."
+            Report Generation Software
+    %section#instructions-for-submitting-implementation-reports
+      :markdown
+        ## Instructions for submitting implementation reports
+
+          Tests should be run using the test manifests defined in the
+          [Test Manifests](#test-manifests) Section.
+
+          The assumed base URI for the tests is `<http://example/base/>` if needed.
+
+          Reports should be submitted in Turtle format to
+          [Public JSON-LD WG](mailto:public-json-ld-wg@w3.org)
+          and include an `earl:Assertion`
+          for each test, referencing the test resource from the associated manifest
+          and the test subject being reported upon. An example test entry is be the following:
+
+              [ a earl:Assertion;
+                earl:assertedBy <--your-developer-identifier-->;
+                earl:subject <--your-software-identifier-->;
+                earl:test <--uri-of-test-from-manifest>;
+                earl:result [
+                  a earl:TestResult;
+                  earl:outcome earl:passed;
+                  dc:date "2016-12-26T10:18:04-08:00"^^xsd:dateTime];
+                earl:mode earl:automatic ] .
+
+          The Test Subject should be defined as a `doap:Project`, including the name,
+          homepage and developer(s) of the software (see [DOAP](https://github.com/edumbill/doap/wiki)). Optionally, including the
+          project description and programming language. An example test subject description is the following:
+
+              <> foaf:primaryTopic <--your-software-identifier--> ;
+                dc:issued "2016-12-26T10:18:04-08:00"^^xsd:dateTime ;
+                foaf:maker <--your-developer-identifier--> .
+
+              <--your-software-identifier--> a doap:Project, earl:TestSubject, earl:Software ;
+                doap:name          "My Cool JSON-LD Parser" ;
+                doap:revision      "Software version number" ;
+                doap:developer     <--your-developer-identifier--> ;
+                doap:homepage      <--your-software-homepace--> ;
+                doap:description   "--your-project-description--"@en ;
+                doap:programming-language "--your-implementation-language--" .
+
+          The software developer, either an organization or one or more individuals SHOULD be
+          referenced from `doap:developer` using [FOAF](http://xmlns.com/foaf/spec). For example:
+
+              <--your-developer-identifier--> a foaf:Person, earl:Assertor;
+                foaf:name "--My Name--";
+                foaf:homepage <--my homepage--> .
+    %section#test-manifests
+      %h2
+        %span.secno="2."
+        Test Manifests
+      - tests['entries'].sort_by {|m| m['title'].to_s.downcase}.each_with_index do |manifest, ndx2|
+        - test_cases = manifest['entries']
+        %section{id: manifest['rdfs:comment'].gsub(' ', '-')}
+          %h2
+            %span.secno="2.#{ndx2+1}"
+            %span<
+              = manifest['title'] ||  'Test Manifest'
+          - Array(manifest['description']).each do |desc|
+            - desc = desc['@value'] if desc.is_a?(Hash)
+            %p{lang: 'en'}<
+              ~ CGI.escapeHTML desc.to_s
+          %table.report
+            - skip_subject = {}
+            - passed_tests[ndx2] = []
+            %tr
+              %th
+                Test
+              - subjects.each_with_index do |subject, index|
+                -# If subject is untested for every test in this manifest, skip it
+                - skip_subject[subject['@id']] = manifest['entries'].all? {|t| t['assertions'][index]['result']['outcome'] == 'earl:untested'}
+                - unless skip_subject[subject['@id']]
+                  %th
+                    %a{href: '#' + subject_refs[subject['@id']]}<=subject['name']
+            - test_cases.each do |test|
+              - test['title'] ||= test['rdfs:label']
+              - test['title'] = Array(test['title']).first
+              %tr
+                %td
+                  %a{href: test['@id']}<
+                    - title = "Test #{test['@id'].split("#").last}: #{CGI.escapeHTML test['title'].to_s}"
+                    - if test.fetch('https://w3c.github.io/json-ld-api/tests/vocab#option', {})['https://w3c.github.io/json-ld-api/tests/vocab#specVersion'] == 'json-ld-1.1'
+                      - title += "(new in JSON-LD 1.1)"
+                    ~ title
+                -# Order assertions by subject name
+                - subjects.each_with_index do |subject, ndx|
+                  - next if skip_subject[subject['@id']]
+                  - assertion = test['assertions'].detect {|a| a['subject'] == subject['@id']}
+                  - pass_fail = assertion['result']['outcome'].split(':').last.upcase.sub(/(PASS|FAIL)ED$/, '\1')
+                  - passed_tests[ndx2][ndx] = (passed_tests[ndx2][ndx] || 0) + (pass_fail == 'PASS' ? 1 : 0)
+                  %td{class: pass_fail}
+                    = pass_fail
+            %tr.summary
+              %td
+                = "Percentage passed out of #{manifest['entries'].length} Tests"
+              - passed_tests[ndx2].compact.each do |r|
+                - pct = (r * 100.0) / manifest['entries'].length
+                %td{class: (pct == 100.0 ? 'passed-all' : (pct >= 95.0 ? 'passed-most' : 'passed-some'))}
+                  = "#{'%.1f' % pct}%"
+    %section.appendix#test-subjects
+      %h2
+        %span.secno="A."
+        Test Subjects
+      %p
+        This report was tested using the following test subjects:
+      %dl
+        - subjects.each_with_index do |subject, index|
+          %dt{id: subject_refs[subject['@id']]}
+            %span.secno="A.#{index+1}"
+            %a{href: subject['@id']}
+              %span{about: subject['@id'], property: "doap:name"}<= subject['name']
+          %dd
+            %dl
+              - if subject['doapDesc']
+                - subject['doapDesc'] = subject['doapDesc']['@value'] if subject['doapDesc'].is_a?(Hash)
+                %dt= "Description"
+                %dd{property: "doap:description", lang: 'en'}<
+                  ~ CGI.escapeHTML subject['doapDesc']
+              - if subject['release']
+                - subject['release'] = subject['release'].first if subject['release'].is_a?(Array)
+                - subject['release']['revision'] = subject['release']['revision']['@value'] if subject['release']['revision'].is_a?(Hash)
+                %dt= "Release"
+                %dd{property: "doap:release"}<
+                  %span{property: "doap:revision"}<
+                    ~ CGI.escapeHTML subject['release']['revision'].to_s
+              - if subject['language']
+                - subject['language'] = subject['language']['@value'] if subject['language'].is_a?(Hash)
+                %dt= "Programming Language"
+                %dd{property: "doap:programming-language"}<
+                  ~ CGI.escapeHTML subject['language'].to_s
+              - if subject['homepage']
+                %dt= "Home Page"
+                %dd
+                  %a{property: "doap:homepage", href: subject['homepage']}
+                    ~ CGI.escapeHTML subject['homepage'].to_s
+              - if subject['developer']
+                %dt= "Developer"
+                - subject['developer'].each do |dev|
+                  %dd{rel: "doap:developer"}
+                    %div
+                      - if dev.has_key?('@id')
+                        %a{href: dev['@id']}
+                          %span{property: "foaf:name"}<
+                            ~ CGI.escapeHTML dev['foaf:name'].to_s
+                      - else
+                        %span{property: "foaf:name"}<
+                      - if dev['foaf:homepage']
+                        %a{property: "foaf:homepage", href: dev['foaf:homepage']}
+                          ~ CGI.escapeHTML dev['foaf:homepage']
+              %dt
+                Test Suite Compliance
+              %dd
+                %table.report
+                  %tbody
+                    - tests['entries'].sort_by {|m| m['title'].to_s.downcase}.each_with_index do |manifest, ndx|
+                      - passed = passed_tests[ndx][index].to_i
+                      - next if passed == 0
+                      - total = manifest['entries'].length
+                      - pct = (passed * 100.0) / total
+                      %tr
+                        %td
+                          ~ manifest['title']
+                        %td{class: (pct == 100.0 ? 'passed-all' : (pct >= 85.0 ? 'passed-most' : 'passed-some'))}
+                          = "#{passed}/#{total} (#{'%.1f' % pct}%)"
+    - unless tests['assertions'].empty?
+      %section.appendix#individual-test-results{rel: "xhv:related earl:assertions"}
+        %h2
+          %span.secno="B."
+          Individual Test Results
+        %p
+          Individual test results used to construct this report are available here:
+        %ul
+          - tests['assertions'].each do |file|
+            %li
+              %a.source{href: file}<= file
+    %section.appendix#report-generation-software{property: "earl:generatedBy", resource: tests['generatedBy']['@id'], typeof: tests['generatedBy']['@type'].join(' ')}
+      %h2
+        %span.secno="D."
+        Report Generation Software
+      - doap = tests['generatedBy']
+      - rel = doap['release']
+      %p
+        This report generated by
+        %span{property: "doap:name"}<
+          %a{href: tests['generatedBy']['@id']}<
+            = doap['name']
+        %meta{property: "doap:shortdesc", content: doap['shortdesc']}
+        %meta{property: "doap:description", content: doap['doapDesc']}
+        version
+        %span{property: "doap:release", resource: rel['@id'], typeof: 'doap:Version'}
+          %span{property: "doap:revision"}<=rel['revision']
+          %meta{property: "doap:name", content: rel['name']}
+          %meta{property: "doap:created", content: rel['created'], datatype: "xsd:date"}
+        an
+        %a{property: "doap:license", href: doap['license']}<="Unlicensed"
+        %span{property: "doap:programming-language"}<="Ruby"
+        application. More information is available at
+        %a{property: "doap:homepage", href: doap['homepage']}<=doap['homepage']
+        = "."
+      %p{property: "doap:developer", resource: "http://greggkellogg.net/foaf#me", typeof: "foaf:Person"}
+        This software is provided by
+        %a{property: "foaf:homepage", href: "http://greggkellogg.net/"}<
+          %span{about: "http://greggkellogg.net/foaf#me", property: "foaf:name"}<
+            Gregg Kellogg
+        in hopes that it might make the lives of conformance testers easier.

--- a/tests/stream-toRdf-manifest.jsonld
+++ b/tests/stream-toRdf-manifest.jsonld
@@ -2,8 +2,8 @@
   "@context": ["https://w3c.github.io/json-ld-api/tests/context.jsonld", {"@base": "stream-toRdf-manifest"}],
   "@id": "",
   "@type": "mf:Manifest",
-  "name": "Streaming",
-  "description": "JSON-LD Streaming tests.",
+  "name": "Streaming Transform JSON-LD to RDF",
+  "description": "JSON-LD Streaming To RDF tests.",
   "baseIri": "https://w3c.github.io/json-ld-streaming/tests/",
   "sequence": [
     {


### PR DESCRIPTION
This PR adds the basic required files for implementation reports.

This PR is however incomplete, as running `earl-report --format json -o earl.jsonld *.ttl` gives the following error:
```
Traceback (most recent call last):
	6: from /Users/rtaelman/.rvm/gems/ruby-2.5.1/bin/ruby_executable_hooks:24:in `<main>'
	5: from /Users/rtaelman/.rvm/gems/ruby-2.5.1/bin/ruby_executable_hooks:24:in `eval'
	4: from /Users/rtaelman/.rvm/gems/ruby-2.5.1/bin/earl-report:23:in `<main>'
	3: from /Users/rtaelman/.rvm/gems/ruby-2.5.1/bin/earl-report:23:in `load'
	2: from /Users/rtaelman/.rvm/gems/ruby-2.5.1/gems/earl-report-0.4.9/bin/earl-report:97:in `<top (required)>'
	1: from /Users/rtaelman/.rvm/gems/ruby-2.5.1/gems/earl-report-0.4.9/bin/earl-report:97:in `new'
/Users/rtaelman/.rvm/gems/ruby-2.5.1/gems/earl-report-0.4.9/lib/earl_report.rb:176:in `initialize': Test Manifests must be specified with :manifest option (RuntimeError)
```

@gkellogg Perhaps you know how I can resolve this problem?