### PR TITLE
Always require @type to come before properties

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@
         </p>
         <ol>
             <li><code>@context</code></li>
-            <li><code>@type</code> where its value indicates a <a class="externalDFN" href="https://www.w3.org/TR/json-ld/#dfn-type-scoped-context">type-scoped context</a>.</li>
+            <li><code>@type</code></li>
             <li><em>Other properties</em></li>
         </ol>
         <p>
@@ -198,8 +198,10 @@
             Only those that are present must occur in the following order.
         </p>
         <p>
-            This order is important because the <code>@context</code> and <code>@type</code> entries
+            This order is important because <code>@context</code>
             can change the meaning of all following entries in the node and its children.
+            Additionally, <code>@type</code> could indicate a <a class="externalDFN" href="https://www.w3.org/TR/json-ld/#dfn-type-scoped-context">type-scoped context</a>,
+            which may have the same implications of an <code>@context</code>.
             This means that these MUST always be processed before all other entries.
         </p>
         <div class="note" role="note" id="key-ordering-json">
@@ -318,16 +320,6 @@
                   "name": "Ruben Taelman",
                   "url": "https://www.rubensworks.net/",
                   "image": "https://www.rubensworks.net/img/ruben.jpg"
-                }
-              </pre>
-              <pre class="example" title="Valid streaming document with @context, plain @type, @id, and other properties">
-                {
-                  "@context": "http://schema.org/",
-                  "@id": "https://www.rubensworks.net/#me", 
-                  "name": "Ruben Taelman",
-                  "url": "https://www.rubensworks.net/",
-                  "image": "https://www.rubensworks.net/img/ruben.jpg",
-                  "@type": "Person" <span class="comment">// Defines no type-scoped context, so may appear anywhere</span>
                 }
               </pre>
           </section>

--- a/tests/stream-toRdf-manifest.html
+++ b/tests/stream-toRdf-manifest.html
@@ -3,7 +3,7 @@
 <head>
 <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
 <title>
-Streaming
+Streaming Transform JSON-LD to RDF
 </title>
 <link href='stream-toRdf-manifest.jsonld' rel='alternate'>
 <link href='https://www.w3.org/StyleSheets/TR/base' rel='stylesheet'>
@@ -14,7 +14,7 @@ Streaming
 <img alt='W3C' height='48' src='http://www.w3.org/Icons/w3c_home' width='72'>
 </a>
 </p>
-<h1>Streaming</h1>
+<h1>Streaming Transform JSON-LD to RDF</h1>
 <p>This is an HTML version of a test manifest. The JSON-LD version of this manifest may be found at
 <a href="stream-toRdf-manifest.jsonld">stream-toRdf-manifest.jsonld</a>. The manifest vocabulary is described in the <a href="vocab.html">JSON-LD Test Vocabulary</a> (<a href="vocab.jsonld">JSON-LD</a>, <a href="vocab.ttl">Turtle</a>) and is based on the <a href="http://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/">RDF Test Vocabulary</a>.</p>
 
@@ -102,7 +102,7 @@ to the <a href="mailto:json-ld-wg@w3.org">JSON-LD Working Group mailing list</a>
 <dt>baseIri</dt>
 <dd>https://w3c.github.io/json-ld-streaming/tests/</dd>
 </dl>
-<p>JSON-LD Streaming tests.</p>
+<p>JSON-LD Streaming To RDF tests.</p>
 <section>
 <h2>
 Test sequence:
@@ -255,6 +255,48 @@ invalid streaming key order
 </dd>
 </dl>
 </dd>
+<dt id='te008'>
+Test te008 @type must come before @id
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#te008</dd>
+<dt>Type</dt>
+<dd>jld:NegativeEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Generate an error if @type comes after @id</dd>
+<dt>input</dt>
+<dd>
+<a href='stream-toRdf/e008-in.jsonld'>stream-toRdf/e008-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+invalid streaming key order
+</dd>
+</dl>
+</dd>
+<dt id='te009'>
+Test te009 @type must come before properties
+</dt>
+<dd>
+<dl class='entry'>
+<dt>id</dt>
+<dd>#te009</dd>
+<dt>Type</dt>
+<dd>jld:NegativeEvaluationTest, jld:ToRDFTest</dd>
+<dt>Purpose</dt>
+<dd>Generate an error if @type comes after properties</dd>
+<dt>input</dt>
+<dd>
+<a href='stream-toRdf/e009-in.jsonld'>stream-toRdf/e009-in.jsonld</a>
+</dd>
+<dt>expect</dt>
+<dd>
+invalid streaming key order
+</dd>
+</dl>
+</dd>
 <dt id='tv001'>
 Test tv001 @context, @id and properties
 </dt>
@@ -378,27 +420,6 @@ Test tv006 @context, @type-scoped context, @id, and other properties
 <dt>expect</dt>
 <dd>
 <a href='stream-toRdf/tv006-out.nq'>stream-toRdf/tv006-out.nq</a>
-</dd>
-</dl>
-</dd>
-<dt id='tv007'>
-Test tv007 @context, plain @type, @id, and other properties
-</dt>
-<dd>
-<dl class='entry'>
-<dt>id</dt>
-<dd>#tv007</dd>
-<dt>Type</dt>
-<dd>jld:PositiveEvaluationTest, jld:ToRDFTest</dd>
-<dt>Purpose</dt>
-<dd>@type without an attached context may appear anywhere</dd>
-<dt>input</dt>
-<dd>
-<a href='stream-toRdf/tv007-in.jsonld'>stream-toRdf/tv007-in.jsonld</a>
-</dd>
-<dt>expect</dt>
-<dd>
-<a href='stream-toRdf/tv007-out.nq'>stream-toRdf/tv007-out.nq</a>
 </dd>
 </dl>
 </dd>

--- a/tests/stream-toRdf-manifest.jsonld
+++ b/tests/stream-toRdf-manifest.jsonld
@@ -56,6 +56,20 @@
       "input": "stream-toRdf/e007-in.jsonld",
       "expectErrorCode": "invalid streaming key order"
     }, {
+      "@id": "#te008",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
+      "name": "@type must come before @id",
+      "purpose": "Generate an error if @type comes after @id",
+      "input": "stream-toRdf/e008-in.jsonld",
+      "expectErrorCode": "invalid streaming key order"
+    }, {
+      "@id": "#te009",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ToRDFTest"],
+      "name": "@type must come before properties",
+      "purpose": "Generate an error if @type comes after properties",
+      "input": "stream-toRdf/e009-in.jsonld",
+      "expectErrorCode": "invalid streaming key order"
+    }, {
       "@id": "#tv001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
       "name": "@context, @id and properties",
@@ -97,13 +111,6 @@
       "purpose": "@context, @type-scoped context, @id, and other properties",
       "input": "stream-toRdf/tv006-in.jsonld",
       "expect": "stream-toRdf/tv006-out.nq"
-    }, {
-      "@id": "#tv007",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],
-      "name": "@context, plain @type, @id, and other properties",
-      "purpose": "@type without an attached context may appear anywhere",
-      "input": "stream-toRdf/tv007-in.jsonld",
-      "expect": "stream-toRdf/tv007-out.nq"
     }, {
       "@id": "#tv008",
       "@type": ["jld:PositiveEvaluationTest", "jld:ToRDFTest"],

--- a/tests/stream-toRdf/e008-in.jsonld
+++ b/tests/stream-toRdf/e008-in.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "name": "http://schema.org/name",
+    "url": "http://schema.org/url",
+    "image": "http://schema.org/image"
+  },
+  "@id": "https://www.rubensworks.net/#me",
+  "@type": "http://schema.org/Person",
+  "name": "Ruben Taelman",
+  "url": "https://www.rubensworks.net/",
+  "image": "https://www.rubensworks.net/img/ruben.jpg"
+}

--- a/tests/stream-toRdf/e009-in.jsonld
+++ b/tests/stream-toRdf/e009-in.jsonld
@@ -1,13 +1,11 @@
 {
   "@context": {
-    "Person": "http://schema.org/Person",
     "name": "http://schema.org/name",
     "url": "http://schema.org/url",
     "image": "http://schema.org/image"
   },
-  "@id": "https://www.rubensworks.net/#me",
   "name": "Ruben Taelman",
+  "@type": "http://schema.org/Person",
   "url": "https://www.rubensworks.net/",
-  "image": "https://www.rubensworks.net/img/ruben.jpg",
-  "@type": "Person"
+  "image": "https://www.rubensworks.net/img/ruben.jpg"
 }

--- a/tests/stream-toRdf/tv007-out.nq
+++ b/tests/stream-toRdf/tv007-out.nq
@@ -1,4 +1,0 @@
-<https://www.rubensworks.net/#me> <http://schema.org/image> "https://www.rubensworks.net/img/ruben.jpg" .
-<https://www.rubensworks.net/#me> <http://schema.org/name> "Ruben Taelman" .
-<https://www.rubensworks.net/#me> <http://schema.org/url> "https://www.rubensworks.net/" .
-<https://www.rubensworks.net/#me> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Person> .


### PR DESCRIPTION
As discussed in #8.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-streaming/pull/11.html" title="Last updated on Apr 3, 2020, 10:10 AM UTC (bd5f09e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-streaming/11/fbd214c...bd5f09e.html" title="Last updated on Apr 3, 2020, 10:10 AM UTC (bd5f09e)">Diff</a>